### PR TITLE
Fix play button showing when not host

### DIFF
--- a/src/net.as
+++ b/src/net.as
@@ -211,6 +211,7 @@ namespace Network {
             // Success!
             auto JsonRoom = Json::Parse(Request.String());
 
+            Room.LocalPlayerIsHost = false;
             Room.MaxPlayers = JsonRoom["size"];
             Room.MapSelection = MapMode(int(JsonRoom["selection"]));
             Room.TargetMedal = Medal(int(JsonRoom["medal"]));


### PR DESCRIPTION
My theory on the bug is that the play button is shown when they've created a room before and joined a new room after. Since the Room object is not recreated, the LocalPlayerIsHost remains true from the time they created the room. This is the behaviour I've observed on Scrapie, Spammie and Wirtual's streams.

This fix assumes that JoinRoom is only called for non-host players. Let me know if that isn't the case!

This PR resolves #12 