### PR TITLE
Prevent always connecting to server on startup

### DIFF
--- a/src/game.as
+++ b/src/game.as
@@ -1,9 +1,18 @@
 // Global active room
 GameRoom@ Room;
+
+// Local room configuration
 RoomConfiguration RoomConfig;
+
+// Name of the local player
 string LocalUsername;
+
 // Milliseconds time until game starts (displayed while loading maps)
 int StartCountdown;
+
+// Persisently saved: whether the game has crashed during a game
+[Setting hidden]
+bool WasConnected = false;
 
 class GameRoom {
     string Name;

--- a/src/main.as
+++ b/src/main.as
@@ -6,7 +6,7 @@ void Main() {
     Config::FetchConfig();
 
     // Plugin was connected to a game when it was forcefully closed or game crashed
-    if (Settings::WasConnected) {
+    if (WasConnected) {
         Network::Init();
     }
 

--- a/src/main.as
+++ b/src/main.as
@@ -6,7 +6,7 @@ void Main() {
     Config::FetchConfig();
 
     // Plugin was connected to a game when it was forcefully closed or game crashed
-    if (Settings::WasConnected || Window::Visible) {
+    if (Settings::WasConnected) {
         Network::Init();
     }
 

--- a/src/main.as
+++ b/src/main.as
@@ -1,10 +1,16 @@
 const string WindowName = Icons::Th + " \\$zBingo";
 const string MenuItemName = "\\$ff0" + WindowName;
 
+float PluginTime = 0.0;
+
 void Main() {
     startnew(Font::Init);
     Config::FetchConfig();
-    Network::Init();
+
+    // Plugin was connected to a game when it was forcefully closed or game crashed
+    if (Settings::WasConnected || Window::Visible) {
+        Network::Init();
+    }
 
     while (true) {
         Network::Loop();
@@ -15,6 +21,10 @@ void Main() {
 void RenderMenu() {
     if (UI::MenuItem(MenuItemName, "", Window::Visible)) {
         Window::Visible = !Window::Visible;
+        // Connect to server when opening plugin window the first time
+        if (Window::Visible && !Network::IsInitialized) {
+            startnew(Network::Init);
+        }
     }
 }
 
@@ -32,5 +42,6 @@ void RenderInterface() {
 
 // TODO: refactor so this is not using the Update callback
 void Update(float dt) {
+    PluginTime += dt;
     Tick(int(dt));
 }

--- a/src/main.as
+++ b/src/main.as
@@ -1,8 +1,6 @@
 const string WindowName = Icons::Th + " \\$zBingo";
 const string MenuItemName = "\\$ff0" + WindowName;
 
-float PluginTime = 0.0;
-
 void Main() {
     startnew(Font::Init);
     Config::FetchConfig();
@@ -42,6 +40,5 @@ void RenderInterface() {
 
 // TODO: refactor so this is not using the Update callback
 void Update(float dt) {
-    PluginTime += dt;
     Tick(int(dt));
 }

--- a/src/net.as
+++ b/src/net.as
@@ -160,6 +160,7 @@ namespace Network {
             NetworkHandlers::LoadMaps(Body["maps"]);
             StartCountdown = 3000; // TODO
             Settings::WasConnected = true;
+            Meta::SaveSettings(); // Ensure WasConnected is saved, even in the event of a crash
         } else if (Body["event"] == "CellClaim") {
             Map@ ClaimedMap = Room.MapList[Body["cell_id"]];
             RunResult Result = RunResult(int(Body["claim"]["time"]), Medal(int(Body["claim"]["medal"])));

--- a/src/net.as
+++ b/src/net.as
@@ -6,6 +6,8 @@ namespace Network {
     Net::Socket@ EventStream = Net::Socket();
     // Suspend UI while a blocking request is happening
     bool RequestInProgress = false;
+    // Indicator if Network::Init() has been called 
+    bool IsInitialized = false;
     // Loop running indicator
     bool IsLooping = false;
     // Connection indicator
@@ -33,6 +35,7 @@ namespace Network {
     }
 
     void Init() {
+        IsInitialized = true;
         _protocol = Protocol();
         TokenExpireDate = 0;
         IsOffline = false;
@@ -40,6 +43,10 @@ namespace Network {
         Received = {};
         FetchAuthToken();
         OpenConnection();
+    }
+
+    ConnectionState GetState() {
+        return _protocol.State;
     }
 
     void FetchAuthToken() {
@@ -71,7 +78,10 @@ namespace Network {
     }
 
     void HandleHandshakeCode(HandshakeCode code) {
-        if (code == HandshakeCode::Ok) return;
+        if (code == HandshakeCode::Ok) {
+            Settings::WasConnected = false;
+            return;
+        }
         if (code == HandshakeCode::CanReconnect) {
             // The server indicates that reconnecting is possible
             trace("Network: Received reconnection handshake code, attempting to reconnect.");
@@ -149,6 +159,7 @@ namespace Network {
         } else if (Body["event"] == "GameStart") {
             NetworkHandlers::LoadMaps(Body["maps"]);
             StartCountdown = 3000; // TODO
+            Settings::WasConnected = true;
         } else if (Body["event"] == "CellClaim") {
             Map@ ClaimedMap = Room.MapList[Body["cell_id"]];
             RunResult Result = RunResult(int(Body["claim"]["time"]), Medal(int(Body["claim"]["medal"])));
@@ -182,6 +193,7 @@ namespace Network {
             Room.EndState.BingoDirection = BingoDirection(int(Body["direction"]));
             Room.EndState.Offset = Body["index"];
             Room.EndState.EndTime = Time::Now;
+            Settings::WasConnected = false;
         } else if (Body["method"] == "MAPS_LOAD_STATUS") {
             Room.MapsLoadingStatus = LoadStatus(int(Body["status"]));
         } else if (Body["method"] == "ROOM_CLOSED"){
@@ -453,6 +465,7 @@ namespace Network {
         auto response = Network::Post("Sync", Json::Object(), false);
         if (response is null) {
             trace("Sync: No reply from server.");
+            Settings::WasConnected = false;
             return;
         }
         @Room = GameRoom();

--- a/src/net.as
+++ b/src/net.as
@@ -79,7 +79,7 @@ namespace Network {
 
     void HandleHandshakeCode(HandshakeCode code) {
         if (code == HandshakeCode::Ok) {
-            Settings::WasConnected = false;
+            WasConnected = false;
             return;
         }
         if (code == HandshakeCode::CanReconnect) {
@@ -159,7 +159,7 @@ namespace Network {
         } else if (Body["event"] == "GameStart") {
             NetworkHandlers::LoadMaps(Body["maps"]);
             StartCountdown = 3000; // TODO
-            Settings::WasConnected = true;
+            WasConnected = true;
             Meta::SaveSettings(); // Ensure WasConnected is saved, even in the event of a crash
         } else if (Body["event"] == "CellClaim") {
             Map@ ClaimedMap = Room.MapList[Body["cell_id"]];
@@ -194,7 +194,7 @@ namespace Network {
             Room.EndState.BingoDirection = BingoDirection(int(Body["direction"]));
             Room.EndState.Offset = Body["index"];
             Room.EndState.EndTime = Time::Now;
-            Settings::WasConnected = false;
+            WasConnected = false;
         } else if (Body["method"] == "MAPS_LOAD_STATUS") {
             Room.MapsLoadingStatus = LoadStatus(int(Body["status"]));
         } else if (Body["method"] == "ROOM_CLOSED"){
@@ -466,7 +466,7 @@ namespace Network {
         auto response = Network::Post("Sync", Json::Object(), false);
         if (response is null) {
             trace("Sync: No reply from server.");
-            Settings::WasConnected = false;
+            WasConnected = false;
             return;
         }
         @Room = GameRoom();

--- a/src/net.as
+++ b/src/net.as
@@ -42,7 +42,7 @@ namespace Network {
         SequenceNext = 0;
         Received = {};
         FetchAuthToken();
-        OpenConnection();
+        IsOffline = !OpenConnection();
     }
 
     ConnectionState GetState() {

--- a/src/settings.as
+++ b/src/settings.as
@@ -13,7 +13,4 @@ namespace Settings {
 
     [Setting name="Developer Mode" category="Debug"]
     bool DevMode = false;
-
-    [Setting hidden]
-    bool WasConnected = false;
 }

--- a/src/settings.as
+++ b/src/settings.as
@@ -13,4 +13,7 @@ namespace Settings {
 
     [Setting name="Developer Mode" category="Debug"]
     bool DevMode = false;
+
+    [Setting hidden]
+    bool WasConnected = false;
 }

--- a/src/util/font.as
+++ b/src/util/font.as
@@ -11,12 +11,19 @@ namespace Font {
 
     void Init() {
         @Regular = UI::LoadFont("assets/SofiaSans-Regular.ttf", 18, -1, -1, true, true, true);
+        yield();
         @Header = UI::LoadFont("assets/SofiaSans-Regular.ttf", 32);
+        yield();
         @Subtitle = UI::LoadFont("assets/SofiaSans-Regular.ttf", 26);
+        yield();
         @MonospaceBig = UI::LoadFont("assets/Inconsolata-Medium.ttf", 26);
+        yield();
         @Monospace = UI::LoadFont("DroidSansMono.ttf", 18, -1, -1, true);
+        yield();
         @Tiny = UI::LoadFont("assets/SofiaSans-Regular.ttf", 11);
+        yield();
         @Bold = UI::LoadFont("assets/SofiaSans-Bold.ttf", 18);
+        yield();
         @Condensed = UI::LoadFont("assets/SofiaSansSemiCondensed-Regular.ttf", 16);
     }
 }

--- a/src/window.as
+++ b/src/window.as
@@ -61,13 +61,11 @@ namespace Window {
 
             if (UI::BeginTabItem(Icons::ShareSquareO + " Join Room")) {
                 JoinTab();
-                ConnectingIndicator();
                 UI::EndTabItem();
             }
 
             if (UI::BeginTabItem(Icons::PlusSquare + " Create Room")) {
                 CreateTab();
-                ConnectingIndicator();
                 UI::EndTabItem();
             }
 
@@ -113,6 +111,7 @@ namespace Window {
     void CreateTab() {
         SettingsView();
         CreateRoomButton();
+        ConnectingIndicator();
     }
 
     void ConnectingIndicator() {
@@ -245,6 +244,7 @@ namespace Window {
             startnew(Network::JoinRoom);
         }
         if (disabled) UI::EndDisabled();
+        ConnectingIndicator();
     }
 
     void RoomView() {

--- a/src/window.as
+++ b/src/window.as
@@ -117,7 +117,7 @@ namespace Window {
     void ConnectingIndicator() {
         if (Network::GetState() != ConnectionState::Connected) {
             UI::SameLine();
-            UI::Text(GetConnectingIcon() + " Connecting to server...");
+            UI::Text("\\$58f" + GetConnectingIcon() + " \\$zConnecting to server...");
         }
     }
 

--- a/src/window.as
+++ b/src/window.as
@@ -51,6 +51,7 @@ namespace Window {
             if (Config::StatusMessage != "") {
                 UI::Text("\\$z" + Icons::InfoCircle + " \\$ff0" + Config::StatusMessage);
             }
+            OfflineIndicator();
 
             UI::BeginTabBar("Bingo_TabBar");
 
@@ -115,9 +116,15 @@ namespace Window {
     }
 
     void ConnectingIndicator() {
-        if (Network::GetState() != ConnectionState::Connected) {
+        if (Network::GetState() != ConnectionState::Connected && !Network::IsOffline) {
             UI::SameLine();
             UI::Text("\\$58f" + GetConnectingIcon() + " \\$zConnecting to server...");
+        }
+    }
+
+    void OfflineIndicator() {
+        if (Network::IsOffline) {
+            UI::Text("\\$f44" + Icons::Exclamation + " \\$zOffline mode: Could not connect to server.");
         }
     }
 

--- a/src/window.as
+++ b/src/window.as
@@ -61,11 +61,13 @@ namespace Window {
 
             if (UI::BeginTabItem(Icons::ShareSquareO + " Join Room")) {
                 JoinTab();
+                ConnectingIndicator();
                 UI::EndTabItem();
             }
 
             if (UI::BeginTabItem(Icons::PlusSquare + " Create Room")) {
                 CreateTab();
+                ConnectingIndicator();
                 UI::EndTabItem();
             }
 
@@ -111,6 +113,22 @@ namespace Window {
     void CreateTab() {
         SettingsView();
         CreateRoomButton();
+    }
+
+    void ConnectingIndicator() {
+        if (Network::GetState() != ConnectionState::Connected) {
+            UI::SameLine();
+            UI::Text(GetConnectingIcon() + " Connecting to server...");
+        }
+    }
+
+    string GetConnectingIcon() {
+        int sequence = int(PluginTime / 333) % 3;
+        if (sequence == 0)
+            return Icons::Kenney::SignalLow;
+        if (sequence == 1)
+            return Icons::Kenney::SignalMedium;
+        return Icons::Kenney::SignalHigh;
     }
 
     void SettingsView() {
@@ -199,7 +217,8 @@ namespace Window {
 
     void CreateRoomButton() {
         UI::NewLine();
-        UI::BeginDisabled(!Config::CanPlay);
+        bool disabled = !Config::CanPlay || Network::GetState() != ConnectionState::Connected;
+        UI::BeginDisabled(disabled);
         UIColor::Lime();
         if (UI::Button(Icons::CheckCircle + " Create Room")) {
             startnew(Network::CreateRoom);
@@ -220,11 +239,12 @@ namespace Window {
         UI::SameLine();
         JoinCodeVisible = UI::Checkbox("Show code", JoinCodeVisible);
 
-        if (!Config::CanPlay) UI::BeginDisabled();
+        bool disabled = !Config::CanPlay || Network::GetState() != ConnectionState::Connected;
+        if (disabled) UI::BeginDisabled();
         if (UI::Button("Join Room") && JoinCodeInput.Length >= 6) {
             startnew(Network::JoinRoom);
         }
-        if (!Config::CanPlay) UI::EndDisabled();
+        if (disabled) UI::EndDisabled();
     }
 
     void RoomView() {

--- a/src/window.as
+++ b/src/window.as
@@ -129,7 +129,7 @@ namespace Window {
     }
 
     string GetConnectingIcon() {
-        int sequence = int(PluginTime / 333) % 3;
+        int sequence = int(Time::Now / 333) % 3;
         if (sequence == 0)
             return Icons::Kenney::SignalLow;
         if (sequence == 1)


### PR DESCRIPTION
As discussed on discord, plugin only connects on startup when it didn't leave a game correctly or when the main window is opened.