### PR TITLE
mapcache: fix TMX scraper pagination/stability

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -20,7 +20,7 @@ To run the server locally:
    ```bash
    cd scripts/mapcache
    mkdir -p ../../db
-   python3 main.py -o ../../db/mapcache.db
+   python3 main.py -o ../../db/mapcache.db -c 100
    cd ../../
    ```
 5. Build and run the server:

--- a/server/scripts/mapcache/README.md
+++ b/server/scripts/mapcache/README.md
@@ -9,10 +9,10 @@ From the `server/scripts/mapcache` directory, run:
 
 ```bash
 pip install --user requests
-python3 main.py
+python3 main.py -o ../../db/mapcache.db
 ```
 
-This will create or update the `db/mapcache.db` file in the project root. Make sure the `db/` directory exists before running the script.
+This will create or update the `db/mapcache.db` file in the server directory. Make sure the `db/` directory exists before running the script.
 
 You can then start the server as usual.
 
@@ -21,3 +21,8 @@ You can then start the server as usual.
 - `-o`, `--output`   : Output file path for the generated SQLite database (default: `./out.db`). To generate the database in the correct location for the server, use `-o ../../db/mapcache.db`.
 - `-i`, `--interval` : Interval (in seconds) between two API requests (default: 10).
 - `-e`, `--errinterval` : Interval (in seconds) before retrying after a failed request (default: 60).
+- `-c`, `--count` : Number of results per API request (TMX max: 1000; default: 100).
+- `--after` : Start pagination after a given TMX MapId (debug/resume).
+- `--max-pages` : Stop after N pages (debug).
+- `--timeout` : HTTP request timeout in seconds (default: 30).
+- `--stats` : Print summary stats after the run.

--- a/server/scripts/mapcache/main.py
+++ b/server/scripts/mapcache/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 import requests
 import argparse
-import os
 import platform
 import json
 import sqlite3
@@ -17,9 +16,14 @@ parser = argparse.ArgumentParser(
     description = 'simple TrackmaniaExchange map metadata exporter.',
 )
 
-parser.add_argument('-o', '--output', help='output file', type=Path, default=Path('./out.db'))
-parser.add_argument('-i', '--interval', help='interval between two requests in seconds (default: 10)', type=int, default=10)
+parser.add_argument('-o', '--output',      help='output file', type=Path, default=Path('./out.db'))
+parser.add_argument('-i', '--interval',    help='interval between two requests in seconds (default: 10)', type=int, default=10)
 parser.add_argument('-e', '--errinterval', help='interval before retrying after a failed request in seconds (default: 60)', type=int, default=60)
+parser.add_argument('-c', '--count',       help='number of results per request (TMX max: 1000). Higher is faster; lower is gentler on the API. (default: 100)', type=int, default=100)
+parser.add_argument('--after',             help='start pagination after this TMX MapId (debug/resume). Note: must be a MapId that appears in /api/maps (unlisted/unreleased maps may return empty). When omitted, starts from the latest maps.', type=int, default=None)
+parser.add_argument('--max-pages',         help='stop after fetching N pages (debug). When omitted, runs until the API reports completion.', type=int, default=None)
+parser.add_argument('--timeout',           help='HTTP request timeout in seconds (default: 30).', type=int, default=30)
+parser.add_argument('--stats',             help='print database stats at the end of the run.', action='store_true')
 
 args = parser.parse_args()
 
@@ -34,26 +38,50 @@ def include_track(map):
     return map["MapType"] == "TM_Race" and map["Vehicle"] == 1
 
 def save_result(page, result):
-    values = [
-        (
-            res["MapId"],
-            res["MapUid"],
-            res["OnlineMapId"],
-            res["Authors"][0]["User"]["UserId"],
-            res["Authors"][0]["User"]["Name"],
-            res["Name"],
-            res["GbxMapName"],
-            res["Medals"]["Author"],
-            res["Medals"]["Gold"],
-            res["Medals"]["Silver"],
-            res["Medals"]["Bronze"],
-            res["UploadedAt"],
-            res["UpdatedAt"],
-            ",".join([str(tag["TagId"]) for tag in res["Tags"]]),
-            res["Tags"][0]["Name"]
+    values = []
+    for res in result:
+        if not include_track(res):
+            continue
+
+        authors = res.get("Authors") or []
+        if not authors:
+            continue
+
+        user = (authors[0] or {}).get("User") or {}
+        userid = user.get("UserId")
+        username = user.get("Name")
+        if userid is None or username is None:
+            continue
+
+        medals = res.get("Medals") or {}
+        author_time = medals.get("Author")
+        gold_time = medals.get("Gold")
+        silver_time = medals.get("Silver")
+        bronze_time = medals.get("Bronze")
+        if None in (author_time, gold_time, silver_time, bronze_time):
+            continue
+
+        tags = res.get("Tags") or []
+        values.append(
+            (
+                res.get("MapId"),
+                res.get("MapUid"),
+                res.get("OnlineMapId"),
+                userid,
+                username,
+                res.get("Name"),
+                res.get("GbxMapName"),
+                author_time,
+                gold_time,
+                silver_time,
+                bronze_time,
+                res.get("UploadedAt"),
+                res.get("UpdatedAt"),
+                ",".join([str(tag.get("TagId")) for tag in tags if tag and tag.get("TagId") is not None]),
+                (tags[0] or {}).get("Name") if tags else None,
+            )
         )
-        for res in result if include_track(res)
-    ]
+
     cur.executemany("INSERT OR REPLACE INTO maps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", values)
     conn.commit()
 
@@ -85,16 +113,24 @@ cur = conn.cursor()
 create_db(cur)
 
 page = 1
-next_param = ""
+next_param = f"&after={args.after}" if args.after is not None else ""
+prev_after = None
 headers = {'user-agent': USER_AGENT}
 fields = urllib.parse.quote_plus("MapId,MapUid,OnlineMapId,Authors[],Name,GbxMapName,Medals.Author,Medals.Gold,Medals.Silver,Medals.Bronze,Vehicle,UploadedAt,UpdatedAt,MapType,Tags[]")
 
 while True:
+    page_count = min(max(args.count, 1), 1000)
+
     log(f'requesting page {page}...', end='')
-    res = requests.get(
-        f"https://trackmania.exchange/api/maps?fields={fields}{next_param}",
-        headers=headers
-    )
+    try:
+        res = requests.get(
+            f"https://trackmania.exchange/api/maps?fields={fields}&count={page_count}{next_param}",
+            headers=headers,
+            timeout=args.timeout,
+        )
+    except requests.RequestException as e:
+        err(e)
+        continue
 
     try:
         res.raise_for_status()
@@ -104,22 +140,59 @@ while True:
 
     try:
         j = json.loads(res.text)
-    except json.JSONError as e:
+    except json.JSONDecodeError as e:
         err(e)
         continue
 
     try:
+        results = j.get("Results") or []
+        if not results:
+            err("TMX returned an empty page of results unexpectedly.")
+            break
+
         save_result(page, j["Results"])
         if not j["More"]:
             print('COMPLETE')
             break
     
-        next_param = f"&after={j['Results'][-1]['MapId']}"
+        after = results[-1]["MapId"]
+        if after == prev_after:
+            if page_count < 1000:
+                err(
+                    f"Pagination cursor did not advance (after={after}). "
+                    f"Increasing --count to 1000 and retrying (was {page_count})."
+                )
+                args.count = 1000
+                continue
+
+            err(f"Pagination cursor did not advance (after={after}). Aborting to avoid an infinite loop.")
+            break
+
+        prev_after = after
+        next_param = f"&after={after}"
     except Exception as e:
         err(e)
-        # SQLite error
         break
 
     print('OK')
     sleep(args.interval)
     page += 1
+
+    if args.max_pages is not None and page > args.max_pages:
+        print('STOPPED (max-pages)')
+        break
+
+if args.stats:
+    cur.execute("SELECT COUNT(*) FROM maps")
+    total = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(*) FROM maps WHERE author_time <= 180000")
+    under_3m = cur.fetchone()[0]
+    cur.execute("SELECT MIN(uploaded_at), MAX(uploaded_at) FROM maps")
+    uploaded_range = cur.fetchone()
+    cur.execute("SELECT COUNT(DISTINCT userid) FROM maps")
+    distinct_users = cur.fetchone()[0]
+    print('STATS:')
+    print('  total_maps:', total)
+    print('  author_time<=180000:', under_3m)
+    print('  uploaded_at_range:', uploaded_range)
+    print('  distinct_userid:', distinct_users)

--- a/server/scripts/mapcache/run.sh
+++ b/server/scripts/mapcache/run.sh
@@ -1,2 +1,16 @@
 #!/usr/bin/env sh
-uv run python3 main.py -o ../../mapcache.db
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+mkdir -p ../../db
+
+if command -v uv >/dev/null 2>&1; then
+  uv run python3 main.py -o ../../db/mapcache.db
+elif command -v python3 >/dev/null 2>&1; then
+  python3 main.py -o ../../db/mapcache.db
+else
+  echo "error: neither 'uv' nor 'python3' was found in PATH" >&2
+  exit 1
+fi

--- a/server/scripts/mapcache/systemd-install.sh
+++ b/server/scripts/mapcache/systemd-install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -euo pipefail
+
+mkdir -p ~/.config/systemd/user
 cat mapcache.service | sed "s+{SCRIPT_PATH}+$PWD+g" > ~/.config/systemd/user/mapcache.service
 cp -f mapcache.timer ~/.config/systemd/user/mapcache.timer
 systemctl --user daemon-reload


### PR DESCRIPTION
Problem: Mapcache generation can stop early (small/biased pool), causing drafts to skew toward newer maps and making many maps/authors rarely/never appear

Fix: Improve TMX scraper pagination/stability and robustness in `server/scripts/mapcache/main.py`. Add CLI options, update `run.sh` and docs

How to test:
- Run: `python server/scripts/mapcache/main.py -o server/db/mapcache.db --stats`
  (or: `server/scripts/mapcache/run.sh`)
- Verify it completes and `--stats` reports a large pool (`total_maps`) and a wide `uploaded_at_range`


AI auto-completion, and context summary was used when preparing the code PR