### PR TITLE
Optimize server broadcast by serializing events once

### DIFF
--- a/server/src/transport/channel.rs
+++ b/server/src/transport/channel.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use serde::Serialize;
+use serde_json::to_vec;
+use tracing::error;
 
 use super::messager::NetMessager;
 
@@ -25,11 +27,19 @@ impl Channel {
     }
 
     pub fn broadcast(&mut self, message: &impl Serialize) {
+        let serialized = match to_vec(message) {
+            Ok(message) => message,
+            Err(e) => {
+                error!("serialization failure: {}", e);
+                return;
+            }
+        };
+
         // send message to all peers and collect closed connections which produced an error
         let closed: Vec<i32> = self
             .peers
             .iter()
-            .filter(|(_, peer)| peer.send(message).is_err_and(|e| e.is_some()))
+            .filter(|(_, peer)| peer.send_serialized(serialized.clone()).is_err())
             .map(|(addr, _)| *addr)
             .collect();
 

--- a/server/src/transport/messager.rs
+++ b/server/src/transport/messager.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use serde::Serialize;
-use serde_json::to_string;
+use serde_json::to_vec;
 use tokio::sync::mpsc::error::SendError;
 use tracing::error;
 
@@ -23,9 +23,13 @@ impl NetMessageWriter {
         Self { writer }
     }
 
+    pub fn send_serialized(&self, message: Vec<u8>) -> Result<(), SendError<Vec<u8>>> {
+        self.writer.send(message)
+    }
+
     /// Send a serialized message to the client.
     pub fn send<T: Serialize>(&self, message: &T) -> Result<(), Option<SendError<Vec<u8>>>> {
-        let serialized = match to_string(message) {
+        let serialized = match to_vec(message) {
             Ok(message) => message,
             Err(e) => {
                 error!("serilization failure: {}", e);
@@ -33,6 +37,6 @@ impl NetMessageWriter {
             }
         };
 
-        self.writer.send(serialized.into_bytes()).map_err(Some)
+        self.send_serialized(serialized).map_err(Some)
     }
 }


### PR DESCRIPTION
Large rooms were spending a disproportionate amount of time in the broadcast path when many players were connected. Channel::broadcast() iterated over every peer and each peer.send(message) re-ran serde_json serialization for the same payload. That meant a single room event was serialized N times for N recipients, which scaled poorly once rooms reached hundreds of players.

This change moves serialization up into Channel::broadcast() so each event is encoded exactly once and the resulting bytes are cloned for each subscriber. NetMessageWriter now exposes a send_serialized() helper for already-encoded payloads, while the existing generic send() path still handles one-off serialization for direct sends.

broadcast_sync() before:
- 100 players: 0.241 ms
- 500 players: 5.093 ms
- 1000 players: 18.935 ms

broadcast_sync() after:
- 100 players: 0.017 ms
- 500 players: 0.183 ms
- 1000 players: 0.675 ms

This message and some of the code is generated with AI but checked by me, a real human. But it of course needs to be tested before being used in production.