### PR TITLE
Adding a benchmark tool

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 /target
 config.toml
 *.db*
+bench-server.log

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "derivative",
  "futures",
  "generational-arena",
+ "libc",
  "once_cell",
  "palette",
  "parking_lot",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -52,6 +52,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +171,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
+ "clap",
  "derivative",
  "futures",
  "generational-arena",
@@ -220,6 +271,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -692,6 +789,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1302,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "overload"
@@ -1934,7 +2049,7 @@ checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2493,6 +2608,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -81,3 +81,6 @@ derivative = "2.2.0"
 
 # CLI argument parsing (used by bench binary)
 clap = { version = "4", features = ["derive"] }
+
+# C library bindings (used by bench for reliable process cleanup)
+libc = "0.2"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -3,6 +3,7 @@ name = "bingohost"
 description = "Server application for Trackmania Bingo."
 version = "1.6.2"
 edition = "2021"
+default-run = "bingohost"
 
 [dependencies]
 # Serialization framework
@@ -77,3 +78,6 @@ pollster = "0.3.0"
 
 # Utility for creating Derive implementations in generated code
 derivative = "2.2.0"
+
+# CLI argument parsing (used by bench binary)
+clap = { version = "4", features = ["derive"] }

--- a/server/README.md
+++ b/server/README.md
@@ -60,3 +60,68 @@ docker run \
 ```
 
 **Important Note:** When using `environment = "dev"` in the config, the server will only bind to the localhost interface and it will not be reachable from outside of the container. To fix that, change the value to `"live"` before deploying.
+
+## Benchmarking
+
+The `bench` binary is an integration-style load-test harness that connects simulated TCP clients to a running server instance.
+
+### Quick start
+
+```bash
+# Build both the server (release) and bench tool
+cargo build --release
+cargo build --bin bench
+
+# Run all scenarios (auto-starts the server)
+cargo run --bin bench -- --scenario all --clients 100 --spawn-server
+```
+
+### Scenarios
+
+| Scenario | Description |
+|---|---|
+| `join_storm` | N clients join a room concurrently. Measures join latency. |
+| `broadcast_fanout` | Host sends a chat message, N clients wait to receive it. Measures broadcast delivery time. |
+| `ping_throughput` | N clients send pings in a loop for `--duration` seconds. Measures req/sec and latency. |
+| `run_submission` | N clients submit runs to every cell on a `--grid-size` board. Requires a populated mapcache DB. |
+| `all` | Runs all of the above in sequence. |
+
+### Options
+
+```
+--scenario <name>       Scenario to run (required)
+--clients <N>           Number of simulated clients (default: 100)
+--server-addr <addr>    Server address (default: 127.0.0.1:5000)
+--duration <secs>       Duration for throughput tests (default: 10)
+--grid-size <N>         Grid size for match scenarios (default: 5)
+--spawn-server          Auto-start a release server using bench.config.toml
+--output <file.json>    Save results to a JSON file
+--compare <file.json>   Compare current run against a previous JSON file
+```
+
+### Comparing runs
+
+Save a baseline, make changes, then compare:
+
+```bash
+# Before
+cargo run --bin bench -- --scenario all --clients 200 --spawn-server --output baseline.json
+
+# After changes
+cargo run --bin bench -- --scenario all --clients 200 --spawn-server --output after.json --compare baseline.json
+```
+
+This prints a side-by-side table with percentage deltas for p50 and p95 latencies.
+
+### Running against an external server
+
+Without `--spawn-server`, the bench tool connects to whatever is at `--server-addr`:
+
+```bash
+cargo run -- --config bench.config.toml   # terminal 1
+cargo run --bin bench -- --scenario join_storm --clients 500   # terminal 2
+```
+
+### Configuration
+
+The `bench.config.toml` file configures the server for benchmarking with auth disabled and rooms that never close. The server accepts a `--config <path>` flag to use an alternative config file.

--- a/server/README.md
+++ b/server/README.md
@@ -92,7 +92,8 @@ cargo run --bin bench -- --scenario all --clients 100 --spawn-server
 --scenario <name>       Scenario to run (required)
 --clients <N>           Number of simulated clients (default: 100)
 --server-addr <addr>    Server address (default: 127.0.0.1:5000)
---duration <secs>       Duration for throughput tests (default: 10)
+--duration <secs>       Duration for throughput tests (default: 3)
+--iterations <N>        Iterations per scenario; median is reported (default: 5)
 --grid-size <N>         Grid size for match scenarios (default: 5)
 --spawn-server          Auto-start a release server using data/config.bench.toml
 --output <file.json>    Save results to a JSON file

--- a/server/README.md
+++ b/server/README.md
@@ -94,7 +94,7 @@ cargo run --bin bench -- --scenario all --clients 100 --spawn-server
 --server-addr <addr>    Server address (default: 127.0.0.1:5000)
 --duration <secs>       Duration for throughput tests (default: 10)
 --grid-size <N>         Grid size for match scenarios (default: 5)
---spawn-server          Auto-start a release server using bench.config.toml
+--spawn-server          Auto-start a release server using data/config.bench.toml
 --output <file.json>    Save results to a JSON file
 --compare <file.json>   Compare current run against a previous JSON file
 ```
@@ -118,10 +118,10 @@ This prints a side-by-side table with percentage deltas for p50 and p95 latencie
 Without `--spawn-server`, the bench tool connects to whatever is at `--server-addr`:
 
 ```bash
-cargo run -- --config bench.config.toml   # terminal 1
+cargo run -- --config data/config.bench.toml   # terminal 1
 cargo run --bin bench -- --scenario join_storm --clients 500   # terminal 2
 ```
 
 ### Configuration
 
-The `bench.config.toml` file configures the server for benchmarking with auth disabled and rooms that never close. The server accepts a `--config <path>` flag to use an alternative config file.
+The `data/config.bench.toml` file configures the server for benchmarking with auth disabled and rooms that never close. The server accepts a `--config <path>` flag to use an alternative config file.

--- a/server/bench.config.toml
+++ b/server/bench.config.toml
@@ -1,0 +1,22 @@
+# Benchmark configuration for the Trackmania Bingo server.
+# Copy this to config.toml before starting the server for benchmarking:
+#   cp bench.config.toml config.toml
+
+environment = "dev"
+
+[network]
+tcp_port = 5000
+http_port = 8080
+timeout = 60
+
+[client]
+required_version = "0.0"
+
+[behaviour]
+never_close = true
+max_teams = 10
+skip_checks = true
+
+[keys]
+openplanet = "KEY"
+webservices = "username:password"

--- a/server/bench.config.toml
+++ b/server/bench.config.toml
@@ -1,6 +1,8 @@
 # Benchmark configuration for the Trackmania Bingo server.
-# Copy this to config.toml before starting the server for benchmarking:
-#   cp bench.config.toml config.toml
+# Use --config bench.config.toml when starting the server, or copy to config.toml.
+#
+# The run_submission scenario requires a populated SQLite map cache
+# (maps table) for map loading to succeed.
 
 environment = "dev"
 

--- a/server/bench.config.toml
+++ b/server/bench.config.toml
@@ -18,6 +18,7 @@ required_version = "0.0"
 never_close = true
 max_teams = 10
 skip_checks = true
+start_countdown = 0
 
 [keys]
 openplanet = "KEY"

--- a/server/data/config.bench.toml
+++ b/server/data/config.bench.toml
@@ -1,5 +1,5 @@
 # Benchmark configuration for the Trackmania Bingo server.
-# Use --config bench.config.toml when starting the server, or copy to config.toml.
+# Use --config data/config.bench.toml when starting the server, or copy to config.toml.
 #
 # The run_submission scenario requires a populated SQLite map cache
 # (maps table) for map loading to succeed.
@@ -10,6 +10,7 @@ environment = "dev"
 tcp_port = 5000
 http_port = 8080
 timeout = 60
+backlog = 4096
 
 [client]
 required_version = "0.0"

--- a/server/data/config.bench.toml
+++ b/server/data/config.bench.toml
@@ -10,7 +10,7 @@ environment = "dev"
 tcp_port = 5000
 http_port = 8080
 timeout = 60
-backlog = 4096
+backlog = 8096
 
 [client]
 required_version = "0.0"

--- a/server/data/config.default.toml
+++ b/server/data/config.default.toml
@@ -9,6 +9,7 @@ environment = "dev"     # or "live"
 tcp_port = 5000             # local port for TCP server
 http_port = 8080            # local port for HTTP server
 timeout = 300               # delay in seconds until TCP connection is closed when idle
+backlog = 512               # TCP listen backlog (pending connection queue size)
 
 [client]
 required_version = "5.0"    # minimum version of the plugin client

--- a/server/src/bin/bench/client.rs
+++ b/server/src/bin/bench/client.rs
@@ -18,6 +18,8 @@ pub struct BenchClient {
     seq: AtomicU32,
     pub player_id: String,
     pub display_name: String,
+    /// Broadcasts received while waiting for a request response.
+    broadcast_buf: Vec<BaseResponse>,
 }
 
 impl BenchClient {
@@ -66,6 +68,7 @@ impl BenchClient {
             seq: AtomicU32::new(1),
             player_id: account_id,
             display_name,
+            broadcast_buf: Vec::new(),
         })
     }
 
@@ -84,7 +87,7 @@ impl BenchClient {
         send_msg(&mut self.framed, &msg).await?;
 
         // Read messages until we get one with our seq.
-        // Non-seq messages (broadcasts) are discarded here.
+        // Non-seq messages (broadcasts) are buffered for recv_any().
         loop {
             let resp: BaseResponse = recv_msg(&mut self.framed).await?;
             if resp.seq == Some(seq) {
@@ -93,11 +96,17 @@ impl BenchClient {
                 }
                 return Ok(resp);
             }
+            // Buffer broadcasts so they aren't lost
+            self.broadcast_buf.push(resp);
         }
     }
 
     /// Wait for the next incoming message (broadcast or response).
+    /// Returns buffered broadcasts first (from messages received during request()).
     pub async fn recv_any(&mut self) -> Result<BaseResponse> {
+        if !self.broadcast_buf.is_empty() {
+            return Ok(self.broadcast_buf.remove(0));
+        }
         recv_msg(&mut self.framed).await
     }
 

--- a/server/src/bin/bench/client.rs
+++ b/server/src/bin/bench/client.rs
@@ -1,0 +1,131 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use bytes::BytesMut;
+use futures::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+use crate::protocol::*;
+
+const IO_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[allow(dead_code)]
+pub struct BenchClient {
+    framed: Framed<TcpStream, LengthDelimitedCodec>,
+    seq: AtomicU32,
+    pub player_id: String,
+    pub display_name: String,
+}
+
+impl BenchClient {
+    /// Connect to the server and complete the handshake.
+    pub async fn connect(addr: &str, index: u32) -> Result<Self> {
+        let account_id = format!("bench-{:08x}", index);
+        let display_name = format!("bench-player-{:04}", index);
+
+        let stream = timeout(IO_TIMEOUT, TcpStream::connect(addr))
+            .await
+            .context("connect timeout")?
+            .context("connect failed")?;
+
+        let codec = LengthDelimitedCodec::builder()
+            .little_endian()
+            .new_codec();
+        let mut framed = Framed::new(stream, codec);
+
+        // Step 1: KeyExchange -> TokenHint
+        let kex = KeyExchangeRequest {
+            key: String::new(),
+            display_name: display_name.clone(),
+            account_id: account_id.clone(),
+        };
+        send_msg(&mut framed, &kex).await?;
+        let token_hint: TokenHint = recv_msg(&mut framed).await?;
+
+        // Step 2: Handshake -> HandshakeResponse
+        let hs = HandshakeRequest {
+            version: "99.0".into(),
+            game: 0,
+            token: token_hint.token,
+        };
+        send_msg(&mut framed, &hs).await?;
+        let hs_resp: HandshakeResponse = recv_msg(&mut framed).await?;
+
+        if !hs_resp.success {
+            bail!(
+                "handshake rejected: {}",
+                hs_resp.reason.unwrap_or_default()
+            );
+        }
+
+        Ok(Self {
+            framed,
+            seq: AtomicU32::new(1),
+            player_id: account_id,
+            display_name,
+        })
+    }
+
+    /// Send a request and wait for the response with matching seq.
+    pub async fn request<T: serde::Serialize>(
+        &mut self,
+        req_type: &str,
+        fields: T,
+    ) -> Result<BaseResponse> {
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+        let msg = BaseRequest {
+            seq,
+            req: req_type.to_string(),
+            fields,
+        };
+        send_msg(&mut self.framed, &msg).await?;
+
+        // Read messages until we get one with our seq.
+        // Non-seq messages (broadcasts) are discarded here.
+        loop {
+            let resp: BaseResponse = recv_msg(&mut self.framed).await?;
+            if resp.seq == Some(seq) {
+                if let Some(ref err) = resp.error {
+                    bail!("server error on {req_type}: {err}");
+                }
+                return Ok(resp);
+            }
+        }
+    }
+
+    /// Wait for the next incoming message (broadcast or response).
+    pub async fn recv_any(&mut self) -> Result<BaseResponse> {
+        recv_msg(&mut self.framed).await
+    }
+
+    /// Send a Ping request.
+    pub async fn ping(&mut self) -> Result<BaseResponse> {
+        self.request("Ping", PingFields {}).await
+    }
+}
+
+async fn send_msg<T: serde::Serialize>(
+    framed: &mut Framed<TcpStream, LengthDelimitedCodec>,
+    msg: &T,
+) -> Result<()> {
+    let json = serde_json::to_string(msg)?;
+    timeout(IO_TIMEOUT, framed.send(json.into()))
+        .await
+        .context("send timeout")?
+        .context("send failed")
+}
+
+async fn recv_msg<T: serde::de::DeserializeOwned>(
+    framed: &mut Framed<TcpStream, LengthDelimitedCodec>,
+) -> Result<T> {
+    let data: BytesMut = timeout(IO_TIMEOUT, framed.next())
+        .await
+        .context("recv timeout")?
+        .ok_or_else(|| anyhow!("connection closed"))?
+        .context("recv failed")?;
+    let text = String::from_utf8(data.to_vec())?;
+    serde_json::from_str(&text).with_context(|| format!("parse failed: {text}"))
+}

--- a/server/src/bin/bench/main.rs
+++ b/server/src/bin/bench/main.rs
@@ -26,8 +26,12 @@ struct Args {
     server_addr: String,
 
     /// Duration in seconds for throughput tests
-    #[arg(long, default_value = "10")]
+    #[arg(long, default_value = "3")]
     duration: u64,
+
+    /// Number of iterations per scenario (median is reported)
+    #[arg(long, default_value = "5")]
+    iterations: u32,
 
     /// Grid size for match scenarios (NxN)
     #[arg(long, default_value = "5")]
@@ -184,6 +188,39 @@ fn pct_change(base: f64, curr: f64) -> f64 {
     ((curr - base) / base) * 100.0
 }
 
+fn median_dur(vals: &mut Vec<Duration>) -> Duration {
+    vals.sort();
+    vals[vals.len() / 2]
+}
+
+fn median_f64(vals: &mut Vec<f64>) -> f64 {
+    vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    vals[vals.len() / 2]
+}
+
+fn median_usize(vals: &mut Vec<usize>) -> usize {
+    vals.sort();
+    vals[vals.len() / 2]
+}
+
+/// Compute the median Stats across multiple runs.
+fn median_stats(runs: &[scenarios::Stats]) -> scenarios::Stats {
+    let mut counts: Vec<usize> = runs.iter().map(|s| s.count).collect();
+    let mut walls: Vec<Duration> = runs.iter().map(|s| s.wall_time).collect();
+    let mut p50s: Vec<Duration> = runs.iter().map(|s| s.p50).collect();
+    let mut p95s: Vec<Duration> = runs.iter().map(|s| s.p95).collect();
+    let mut p99s: Vec<Duration> = runs.iter().map(|s| s.p99).collect();
+    let mut maxes: Vec<Duration> = runs.iter().map(|s| s.max).collect();
+    scenarios::Stats {
+        count: median_usize(&mut counts),
+        wall_time: median_dur(&mut walls),
+        p50: median_dur(&mut p50s),
+        p95: median_dur(&mut p95s),
+        p99: median_dur(&mut p99s),
+        max: median_dur(&mut maxes),
+    }
+}
+
 struct ServerGuard {
     child: Child,
     addr: String,
@@ -274,8 +311,9 @@ async fn main() {
         other => vec![other],
     };
 
+    let iterations = args.iterations.max(1);
     println!(
-        "bench: scenarios={}, clients={}, addr={server_addr}",
+        "bench: scenarios={}, clients={}, iterations={iterations}, addr={server_addr}",
         to_run.join(","),
         args.clients,
     );
@@ -286,29 +324,70 @@ async fn main() {
     for scenario in &to_run {
         println!("\n--- {scenario} ---");
         match *scenario {
-            "join_storm" => match scenarios::join_storm(&server_addr, args.clients).await {
-                Ok(stats) => rows.push(Row { name: "Join Storm".into(), stats, extra: None }),
-                Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+            "join_storm" => {
+                let mut runs = Vec::new();
+                for i in 0..iterations {
+                    if iterations > 1 { println!("  iteration {}/{iterations}", i + 1); }
+                    match scenarios::join_storm(&server_addr, args.clients).await {
+                        Ok(stats) => runs.push(stats),
+                        Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+                    }
+                }
+                if !runs.is_empty() {
+                    rows.push(Row { name: "Join Storm".into(), stats: median_stats(&runs), extra: None });
+                }
             },
-            "broadcast_fanout" => match scenarios::broadcast_fanout(&server_addr, args.clients).await {
-                Ok(stats) => rows.push(Row { name: "Broadcast Fan-out".into(), stats, extra: None }),
-                Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+            "broadcast_fanout" => {
+                let mut runs = Vec::new();
+                for i in 0..iterations {
+                    if iterations > 1 { println!("  iteration {}/{iterations}", i + 1); }
+                    match scenarios::broadcast_fanout(&server_addr, args.clients).await {
+                        Ok(stats) => runs.push(stats),
+                        Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+                    }
+                }
+                if !runs.is_empty() {
+                    rows.push(Row { name: "Broadcast Fan-out".into(), stats: median_stats(&runs), extra: None });
+                }
             },
-            "ping_throughput" => match scenarios::ping_throughput(&server_addr, args.clients, args.duration).await {
-                Ok(ping_stats) => {
-                    let total = ping_stats.total_requests;
-                    let rps = total as f64 / ping_stats.wall_time.as_secs_f64();
+            "ping_throughput" => {
+                let mut runs = Vec::new();
+                let mut extras: Vec<(u64, f64)> = Vec::new();
+                for i in 0..iterations {
+                    if iterations > 1 { println!("  iteration {}/{iterations}", i + 1); }
+                    match scenarios::ping_throughput(&server_addr, args.clients, args.duration).await {
+                        Ok(ping_stats) => {
+                            let total = ping_stats.total_requests;
+                            let rps = total as f64 / ping_stats.wall_time.as_secs_f64();
+                            extras.push((total, rps));
+                            runs.push(ping_stats.latency);
+                        }
+                        Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+                    }
+                }
+                if !runs.is_empty() {
+                    let mut rps_vals: Vec<f64> = extras.iter().map(|(_, rps)| *rps).collect();
+                    let median_rps = median_f64(&mut rps_vals);
+                    let median_total = extras[extras.len() / 2].0;
                     rows.push(Row {
                         name: "Ping Throughput".into(),
-                        stats: ping_stats.latency,
-                        extra: Some(format!("{total} reqs, {rps:.0} agg req/s")),
+                        stats: median_stats(&runs),
+                        extra: Some(format!("{median_total} reqs, {median_rps:.0} agg req/s")),
                     });
                 }
-                Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
             },
-            "run_submission" => match scenarios::run_submission(&server_addr, args.clients, args.grid_size).await {
-                Ok(stats) => rows.push(Row { name: "Run Submission".into(), stats, extra: None }),
-                Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+            "run_submission" => {
+                let mut runs = Vec::new();
+                for i in 0..iterations {
+                    if iterations > 1 { println!("  iteration {}/{iterations}", i + 1); }
+                    match scenarios::run_submission(&server_addr, args.clients, args.grid_size).await {
+                        Ok(stats) => runs.push(stats),
+                        Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+                    }
+                }
+                if !runs.is_empty() {
+                    rows.push(Row { name: "Run Submission".into(), stats: median_stats(&runs), extra: None });
+                }
             },
             other => {
                 eprintln!("unknown scenario: {other}");

--- a/server/src/bin/bench/main.rs
+++ b/server/src/bin/bench/main.rs
@@ -221,6 +221,20 @@ fn median_stats(runs: &[scenarios::Stats]) -> scenarios::Stats {
     }
 }
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// PID of the spawned server process, used to ensure cleanup on exit.
+static SERVER_PID: AtomicU32 = AtomicU32::new(0);
+
+/// Kill the server process by PID. Safe to call multiple times.
+fn kill_server_pid() {
+    let pid = SERVER_PID.swap(0, Ordering::SeqCst);
+    if pid != 0 {
+        unsafe { libc::kill(pid as i32, libc::SIGKILL); }
+        unsafe { libc::waitpid(pid as i32, std::ptr::null_mut(), 0); }
+    }
+}
+
 struct ServerGuard {
     child: Child,
     addr: String,
@@ -228,9 +242,10 @@ struct ServerGuard {
 
 impl Drop for ServerGuard {
     fn drop(&mut self) {
-        println!("  shutting down server...");
+        eprintln!("  shutting down server...");
         let _ = self.child.kill();
         let _ = self.child.wait();
+        SERVER_PID.store(0, Ordering::SeqCst);
     }
 }
 
@@ -241,6 +256,29 @@ fn spawn_server() -> ServerGuard {
     let server_bin = server_dir.join("target/release/bingohost");
     let bench_config = server_dir.join("data/config.bench.toml");
     let log_path = server_dir.join("bench-server.log");
+
+    let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    // Fail early if the port is already occupied
+    if TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
+        eprintln!("error: port {} is already in use — kill the existing server first", addr.port());
+        std::process::exit(1);
+    }
+
+    // Build the release server binary so we never run a stale one
+    print!("  building release server...");
+    let build_status = Command::new("cargo")
+        .current_dir(server_dir)
+        .args(["build", "--release", "--bin", "bingohost"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .status()
+        .expect("failed to run cargo build");
+    if !build_status.success() {
+        eprintln!(" FAILED (exit {})", build_status);
+        std::process::exit(1);
+    }
+    println!(" ok");
 
     println!("  starting server from {}", server_bin.display());
 
@@ -260,10 +298,18 @@ fn spawn_server() -> ServerGuard {
         });
 
     // Poll TCP until the server is accepting connections
-    let addr = "127.0.0.1:5000";
     print!("  waiting for server to be ready...");
     let deadline = std::time::Instant::now() + Duration::from_secs(15);
     loop {
+        // Check the child hasn't already exited (e.g. crash on startup)
+        if let Some(status) = child.try_wait().expect("failed to check server status") {
+            eprintln!("\n\nserver exited immediately with {status}. Server output:");
+            if let Ok(log) = std::fs::read_to_string(&log_path) {
+                eprintln!("{log}");
+            }
+            std::process::exit(1);
+        }
+
         if std::time::Instant::now() > deadline {
             eprintln!("\n\nserver did not become ready within 15s. Server output:");
             if let Ok(log) = std::fs::read_to_string(&log_path) {
@@ -273,15 +319,14 @@ fn spawn_server() -> ServerGuard {
             let _ = child.wait();
             std::process::exit(1);
         }
-        if TcpStream::connect_timeout(
-            &addr.parse().unwrap(),
-            Duration::from_millis(100),
-        ).is_ok() {
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
             break;
         }
         std::thread::sleep(Duration::from_millis(100));
     }
     println!(" ready");
+
+    SERVER_PID.store(child.id(), Ordering::SeqCst);
 
     ServerGuard {
         child,
@@ -289,8 +334,20 @@ fn spawn_server() -> ServerGuard {
     }
 }
 
+extern "C" fn atexit_kill_server() {
+    kill_server_pid();
+}
+
 #[tokio::main]
 async fn main() {
+    // Ensure the server subprocess is killed on Ctrl-C, panic, or normal exit.
+    unsafe { libc::atexit(atexit_kill_server); }
+    tokio::spawn(async {
+        tokio::signal::ctrl_c().await.ok();
+        kill_server_pid();
+        std::process::exit(130);
+    });
+
     let args = Args::parse();
 
     let _server_guard: Option<ServerGuard>;

--- a/server/src/bin/bench/main.rs
+++ b/server/src/bin/bench/main.rs
@@ -1,0 +1,180 @@
+mod client;
+mod protocol;
+mod scenarios;
+
+use std::net::TcpStream;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "bench", about = "Benchmark harness for the Trackmania Bingo server")]
+struct Args {
+    /// Scenario to run: join_storm, broadcast_fanout, ping_throughput
+    #[arg(long)]
+    scenario: String,
+
+    /// Number of simulated clients
+    #[arg(long, default_value = "100")]
+    clients: u32,
+
+    /// Server address (ignored when --spawn-server is used)
+    #[arg(long, default_value = "127.0.0.1:5000")]
+    server_addr: String,
+
+    /// Duration in seconds for throughput tests
+    #[arg(long, default_value = "10")]
+    duration: u64,
+
+    /// Automatically start the server as a subprocess (uses bench.config.toml)
+    #[arg(long)]
+    spawn_server: bool,
+}
+
+fn fmt_duration(d: Duration) -> String {
+    if d.as_millis() < 1 {
+        format!("{:.0}us", d.as_micros())
+    } else if d.as_secs() < 1 {
+        format!("{:.1}ms", d.as_secs_f64() * 1000.0)
+    } else {
+        format!("{:.2}s", d.as_secs_f64())
+    }
+}
+
+fn print_stats(label: &str, stats: &scenarios::Stats) {
+    let throughput = stats.count as f64 / stats.wall_time.as_secs_f64();
+    println!();
+    println!("  {label}");
+    println!("  {:-<50}", "");
+    println!("  Completed:  {}", stats.count);
+    println!("  Wall time:  {}", fmt_duration(stats.wall_time));
+    println!("  Throughput: {throughput:.1} ops/sec");
+    println!("  p50:        {}", fmt_duration(stats.p50));
+    println!("  p95:        {}", fmt_duration(stats.p95));
+    println!("  p99:        {}", fmt_duration(stats.p99));
+    println!("  max:        {}", fmt_duration(stats.max));
+}
+
+struct ServerGuard {
+    child: Child,
+    addr: String,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        println!("  shutting down server...");
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn the server binary as a child process, wait for it to be ready.
+/// The returned guard kills the server on drop.
+fn spawn_server() -> ServerGuard {
+    let server_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let server_bin = server_dir.join("target/release/bingohost");
+    let bench_config = server_dir.join("bench.config.toml");
+    let log_path = server_dir.join("bench-server.log");
+
+    println!("  starting server from {}", server_bin.display());
+
+    let log_file = std::fs::File::create(&log_path).expect("cannot create server log file");
+
+    let mut child = Command::new(&server_bin)
+        .current_dir(server_dir)
+        .args(["--config", bench_config.to_str().unwrap()])
+        .stderr(log_file)
+        .stdout(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| {
+            panic!(
+                "failed to start server at {}: {e}\nhint: run `cargo build --release` first",
+                server_bin.display()
+            )
+        });
+
+    // Poll TCP until the server is accepting connections
+    let addr = "127.0.0.1:5000";
+    print!("  waiting for server to be ready...");
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if std::time::Instant::now() > deadline {
+            eprintln!("\n\nserver did not become ready within 15s. Server output:");
+            if let Ok(log) = std::fs::read_to_string(&log_path) {
+                eprintln!("{log}");
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+            std::process::exit(1);
+        }
+        if TcpStream::connect_timeout(
+            &addr.parse().unwrap(),
+            Duration::from_millis(100),
+        ).is_ok() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    println!(" ready");
+
+    ServerGuard {
+        child,
+        addr: addr.to_string(),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    let _server_guard: Option<ServerGuard>;
+    let server_addr;
+
+    if args.spawn_server {
+        println!("bench: spawning server...");
+        let guard = spawn_server();
+        server_addr = guard.addr.clone();
+        _server_guard = Some(guard);
+    } else {
+        _server_guard = None;
+        server_addr = args.server_addr.clone();
+    }
+
+    println!("bench: scenario={}, clients={}, addr={server_addr}", args.scenario, args.clients);
+
+    let result = match args.scenario.as_str() {
+        "join_storm" => {
+            scenarios::join_storm(&server_addr, args.clients)
+                .await
+                .map(|stats| print_stats("Join Storm", &stats))
+        }
+        "broadcast_fanout" => {
+            scenarios::broadcast_fanout(&server_addr, args.clients)
+                .await
+                .map(|stats| print_stats("Broadcast Fan-out", &stats))
+        }
+        "ping_throughput" => {
+            scenarios::ping_throughput(&server_addr, args.clients, args.duration)
+                .await
+                .map(|ping_stats| {
+                    print_stats("Ping Throughput", &ping_stats.latency);
+                    let rps = ping_stats.total_requests as f64 / ping_stats.wall_time.as_secs_f64();
+                    println!("  Total reqs: {}", ping_stats.total_requests);
+                    println!("  Aggregate:  {rps:.1} req/sec");
+                })
+        }
+        other => {
+            eprintln!("unknown scenario: {other}");
+            eprintln!("available: join_storm, broadcast_fanout, ping_throughput");
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("\nERROR: {e:#}");
+        std::process::exit(1);
+    }
+
+    println!();
+}

--- a/server/src/bin/bench/main.rs
+++ b/server/src/bin/bench/main.rs
@@ -33,7 +33,7 @@ struct Args {
     #[arg(long, default_value = "5")]
     grid_size: u32,
 
-    /// Automatically start the server as a subprocess (uses bench.config.toml)
+    /// Automatically start the server as a subprocess (uses data/config.bench.toml)
     #[arg(long)]
     spawn_server: bool,
 
@@ -202,7 +202,7 @@ impl Drop for ServerGuard {
 fn spawn_server() -> ServerGuard {
     let server_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let server_bin = server_dir.join("target/release/bingohost");
-    let bench_config = server_dir.join("bench.config.toml");
+    let bench_config = server_dir.join("data/config.bench.toml");
     let log_path = server_dir.join("bench-server.log");
 
     println!("  starting server from {}", server_bin.display());

--- a/server/src/bin/bench/main.rs
+++ b/server/src/bin/bench/main.rs
@@ -2,11 +2,13 @@ mod client;
 mod protocol;
 mod scenarios;
 
+use std::collections::HashMap;
 use std::net::TcpStream;
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
 use clap::Parser;
+use serde::{Deserialize, Serialize};
 
 #[derive(Parser)]
 #[command(name = "bench", about = "Benchmark harness for the Trackmania Bingo server")]
@@ -34,6 +36,14 @@ struct Args {
     /// Automatically start the server as a subprocess (uses bench.config.toml)
     #[arg(long)]
     spawn_server: bool,
+
+    /// Save results to a JSON file
+    #[arg(long)]
+    output: Option<String>,
+
+    /// Compare results against a previous JSON file
+    #[arg(long)]
+    compare: Option<String>,
 }
 
 fn fmt_dur(d: Duration) -> String {
@@ -77,6 +87,101 @@ fn print_table(rows: &[Row]) {
         );
     }
     println!();
+}
+
+// -- JSON output / compare --
+
+#[derive(Serialize, Deserialize)]
+struct RunResult {
+    timestamp: String,
+    git_commit: Option<String>,
+    clients: u32,
+    scenarios: HashMap<String, ScenarioResult>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct ScenarioResult {
+    count: usize,
+    wall_time_ms: f64,
+    p50_ms: f64,
+    p95_ms: f64,
+    p99_ms: f64,
+    max_ms: f64,
+    throughput: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra: Option<String>,
+}
+
+fn dur_ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+fn rows_to_result(rows: &[Row], clients: u32) -> RunResult {
+    let git_commit = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string());
+
+    let mut scenarios = HashMap::new();
+    for row in rows {
+        let s = &row.stats;
+        scenarios.insert(row.name.clone(), ScenarioResult {
+            count: s.count,
+            wall_time_ms: dur_ms(s.wall_time),
+            p50_ms: dur_ms(s.p50),
+            p95_ms: dur_ms(s.p95),
+            p99_ms: dur_ms(s.p99),
+            max_ms: dur_ms(s.max),
+            throughput: s.count as f64 / s.wall_time.as_secs_f64(),
+            extra: row.extra.clone(),
+        });
+    }
+
+    RunResult {
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        git_commit,
+        clients,
+        scenarios,
+    }
+}
+
+fn print_comparison(current: &RunResult, baseline: &RunResult) {
+    println!();
+    println!("  Comparison vs baseline ({})", baseline.git_commit.as_deref().unwrap_or("unknown"));
+    println!("  {}", "-".repeat(90));
+    println!(
+        "  {:<20} {:>12} {:>12} {:>10}  {:>12} {:>12} {:>10}",
+        "Scenario", "base p50", "curr p50", "delta", "base p95", "curr p95", "delta"
+    );
+    println!("  {}", "-".repeat(90));
+
+    let mut names: Vec<&String> = current.scenarios.keys().collect();
+    names.sort();
+
+    for name in names {
+        let curr = &current.scenarios[name];
+        if let Some(base) = baseline.scenarios.get(name) {
+            let p50_delta = pct_change(base.p50_ms, curr.p50_ms);
+            let p95_delta = pct_change(base.p95_ms, curr.p95_ms);
+            println!(
+                "  {:<20} {:>10.1}ms {:>10.1}ms {:>+9.1}%  {:>10.1}ms {:>10.1}ms {:>+9.1}%",
+                name,
+                base.p50_ms, curr.p50_ms, p50_delta,
+                base.p95_ms, curr.p95_ms, p95_delta,
+            );
+        } else {
+            println!("  {:<20} {:>12} {:>10.1}ms {:>10}  {:>12} {:>10.1}ms {:>10}",
+                name, "-", curr.p50_ms, "new", "-", curr.p95_ms, "new");
+        }
+    }
+    println!();
+}
+
+fn pct_change(base: f64, curr: f64) -> f64 {
+    if base == 0.0 { return 0.0; }
+    ((curr - base) / base) * 100.0
 }
 
 struct ServerGuard {
@@ -215,6 +320,30 @@ async fn main() {
 
     if !rows.is_empty() {
         print_table(&rows);
+    }
+
+    // Save results to JSON
+    if let Some(ref path) = args.output {
+        let result = rows_to_result(&rows, args.clients);
+        let json = serde_json::to_string_pretty(&result).expect("json serialization failed");
+        std::fs::write(path, &json).unwrap_or_else(|e| {
+            eprintln!("failed to write output to {path}: {e}");
+        });
+        println!("  results saved to {path}");
+    }
+
+    // Compare against baseline
+    if let Some(ref path) = args.compare {
+        match std::fs::read_to_string(path) {
+            Ok(json) => match serde_json::from_str::<RunResult>(&json) {
+                Ok(baseline) => {
+                    let current = rows_to_result(&rows, args.clients);
+                    print_comparison(&current, &baseline);
+                }
+                Err(e) => eprintln!("failed to parse baseline {path}: {e}"),
+            },
+            Err(e) => eprintln!("failed to read baseline {path}: {e}"),
+        }
     }
 
     if had_error {

--- a/server/src/bin/bench/main.rs
+++ b/server/src/bin/bench/main.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[command(name = "bench", about = "Benchmark harness for the Trackmania Bingo server")]
 struct Args {
-    /// Scenario to run: join_storm, broadcast_fanout, ping_throughput
+    /// Scenario to run: all, join_storm, broadcast_fanout, ping_throughput, run_submission
     #[arg(long)]
     scenario: String,
 
@@ -27,12 +27,16 @@ struct Args {
     #[arg(long, default_value = "10")]
     duration: u64,
 
+    /// Grid size for match scenarios (NxN)
+    #[arg(long, default_value = "5")]
+    grid_size: u32,
+
     /// Automatically start the server as a subprocess (uses bench.config.toml)
     #[arg(long)]
     spawn_server: bool,
 }
 
-fn fmt_duration(d: Duration) -> String {
+fn fmt_dur(d: Duration) -> String {
     if d.as_millis() < 1 {
         format!("{:.0}us", d.as_micros())
     } else if d.as_secs() < 1 {
@@ -42,18 +46,37 @@ fn fmt_duration(d: Duration) -> String {
     }
 }
 
-fn print_stats(label: &str, stats: &scenarios::Stats) {
-    let throughput = stats.count as f64 / stats.wall_time.as_secs_f64();
+struct Row {
+    name: String,
+    stats: scenarios::Stats,
+    extra: Option<String>,
+}
+
+fn print_table(rows: &[Row]) {
+    // Header
     println!();
-    println!("  {label}");
-    println!("  {:-<50}", "");
-    println!("  Completed:  {}", stats.count);
-    println!("  Wall time:  {}", fmt_duration(stats.wall_time));
-    println!("  Throughput: {throughput:.1} ops/sec");
-    println!("  p50:        {}", fmt_duration(stats.p50));
-    println!("  p95:        {}", fmt_duration(stats.p95));
-    println!("  p99:        {}", fmt_duration(stats.p99));
-    println!("  max:        {}", fmt_duration(stats.max));
+    println!(
+        "  {:<20} {:>7} {:>9} {:>9} {:>9} {:>9} {:>9} {:>12}  {}",
+        "Scenario", "Ops", "Wall", "p50", "p95", "p99", "Max", "Throughput", "Extra"
+    );
+    println!("  {}", "-".repeat(105));
+
+    for row in rows {
+        let throughput = row.stats.count as f64 / row.stats.wall_time.as_secs_f64();
+        println!(
+            "  {:<20} {:>7} {:>9} {:>9} {:>9} {:>9} {:>9} {:>10.1}/s  {}",
+            row.name,
+            row.stats.count,
+            fmt_dur(row.stats.wall_time),
+            fmt_dur(row.stats.p50),
+            fmt_dur(row.stats.p95),
+            fmt_dur(row.stats.p99),
+            fmt_dur(row.stats.max),
+            throughput,
+            row.extra.as_deref().unwrap_or(""),
+        );
+    }
+    println!();
 }
 
 struct ServerGuard {
@@ -141,40 +164,60 @@ async fn main() {
         server_addr = args.server_addr.clone();
     }
 
-    println!("bench: scenario={}, clients={}, addr={server_addr}", args.scenario, args.clients);
-
-    let result = match args.scenario.as_str() {
-        "join_storm" => {
-            scenarios::join_storm(&server_addr, args.clients)
-                .await
-                .map(|stats| print_stats("Join Storm", &stats))
-        }
-        "broadcast_fanout" => {
-            scenarios::broadcast_fanout(&server_addr, args.clients)
-                .await
-                .map(|stats| print_stats("Broadcast Fan-out", &stats))
-        }
-        "ping_throughput" => {
-            scenarios::ping_throughput(&server_addr, args.clients, args.duration)
-                .await
-                .map(|ping_stats| {
-                    print_stats("Ping Throughput", &ping_stats.latency);
-                    let rps = ping_stats.total_requests as f64 / ping_stats.wall_time.as_secs_f64();
-                    println!("  Total reqs: {}", ping_stats.total_requests);
-                    println!("  Aggregate:  {rps:.1} req/sec");
-                })
-        }
-        other => {
-            eprintln!("unknown scenario: {other}");
-            eprintln!("available: join_storm, broadcast_fanout, ping_throughput");
-            std::process::exit(1);
-        }
+    let to_run: Vec<&str> = match args.scenario.as_str() {
+        "all" => vec!["join_storm", "broadcast_fanout", "ping_throughput", "run_submission"],
+        other => vec![other],
     };
 
-    if let Err(e) = result {
-        eprintln!("\nERROR: {e:#}");
-        std::process::exit(1);
+    println!(
+        "bench: scenarios={}, clients={}, addr={server_addr}",
+        to_run.join(","),
+        args.clients,
+    );
+
+    let mut rows: Vec<Row> = Vec::new();
+    let mut had_error = false;
+
+    for scenario in &to_run {
+        println!("\n--- {scenario} ---");
+        match *scenario {
+            "join_storm" => match scenarios::join_storm(&server_addr, args.clients).await {
+                Ok(stats) => rows.push(Row { name: "Join Storm".into(), stats, extra: None }),
+                Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+            },
+            "broadcast_fanout" => match scenarios::broadcast_fanout(&server_addr, args.clients).await {
+                Ok(stats) => rows.push(Row { name: "Broadcast Fan-out".into(), stats, extra: None }),
+                Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+            },
+            "ping_throughput" => match scenarios::ping_throughput(&server_addr, args.clients, args.duration).await {
+                Ok(ping_stats) => {
+                    let total = ping_stats.total_requests;
+                    let rps = total as f64 / ping_stats.wall_time.as_secs_f64();
+                    rows.push(Row {
+                        name: "Ping Throughput".into(),
+                        stats: ping_stats.latency,
+                        extra: Some(format!("{total} reqs, {rps:.0} agg req/s")),
+                    });
+                }
+                Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+            },
+            "run_submission" => match scenarios::run_submission(&server_addr, args.clients, args.grid_size).await {
+                Ok(stats) => rows.push(Row { name: "Run Submission".into(), stats, extra: None }),
+                Err(e) => { eprintln!("  ERROR: {e:#}"); had_error = true; }
+            },
+            other => {
+                eprintln!("unknown scenario: {other}");
+                eprintln!("available: all, join_storm, broadcast_fanout, ping_throughput, run_submission");
+                std::process::exit(1);
+            }
+        }
     }
 
-    println!();
+    if !rows.is_empty() {
+        print_table(&rows);
+    }
+
+    if had_error {
+        std::process::exit(1);
+    }
 }

--- a/server/src/bin/bench/main.rs
+++ b/server/src/bin/bench/main.rs
@@ -348,6 +348,15 @@ async fn main() {
         std::process::exit(130);
     });
 
+    // Raise the file descriptor limit so we can handle many concurrent connections.
+    // The spawned server inherits this limit.
+    unsafe {
+        let mut rlim: libc::rlimit = std::mem::zeroed();
+        libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim);
+        rlim.rlim_cur = rlim.rlim_max.min(65536);
+        libc::setrlimit(libc::RLIMIT_NOFILE, &rlim);
+    }
+
     let args = Args::parse();
 
     let _server_guard: Option<ServerGuard>;

--- a/server/src/bin/bench/protocol.rs
+++ b/server/src/bin/bench/protocol.rs
@@ -118,6 +118,23 @@ pub struct SendChatMessageFields {
     pub message: String,
 }
 
+#[derive(Serialize)]
+pub struct StartMatchFields {}
+
+#[derive(Serialize)]
+pub struct JoinMatchFields {
+    pub uid: String,
+    pub team_id: Option<usize>,
+}
+
+#[derive(Serialize)]
+pub struct SubmitRunFields {
+    pub tile_index: usize,
+    pub time: u64,
+    pub medal: u8,
+    pub splits: Vec<u64>,
+}
+
 // -- Helpers --
 
 impl Default for RoomConfig {

--- a/server/src/bin/bench/protocol.rs
+++ b/server/src/bin/bench/protocol.rs
@@ -1,0 +1,174 @@
+use serde::{Deserialize, Serialize};
+
+// -- Handshake phase --
+
+#[derive(Serialize)]
+pub struct KeyExchangeRequest {
+    pub key: String,
+    pub display_name: String,
+    pub account_id: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct TokenHint {
+    pub token: String,
+}
+
+#[derive(Serialize)]
+pub struct HandshakeRequest {
+    pub version: String,
+    pub game: u8,
+    pub token: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct HandshakeResponse {
+    pub success: bool,
+    pub reason: Option<String>,
+}
+
+// -- Main loop requests --
+
+#[derive(Serialize)]
+pub struct BaseRequest<T: Serialize> {
+    pub seq: u32,
+    pub req: String,
+    #[serde(flatten)]
+    pub fields: T,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct BaseResponse {
+    pub seq: Option<u32>,
+    pub error: Option<String>,
+    #[serde(flatten)]
+    pub fields: serde_json::Value,
+}
+
+// -- Request payloads --
+
+#[derive(Serialize)]
+pub struct PingFields {}
+
+#[derive(Serialize)]
+pub struct CreateRoomFields {
+    pub config: RoomConfig,
+    pub match_config: MatchConfig,
+    pub teams: Vec<Team>,
+}
+
+#[derive(Serialize)]
+pub struct RoomConfig {
+    pub name: String,
+    pub public: bool,
+    pub randomize: bool,
+    pub size: u32,
+    pub host_control: bool,
+}
+
+#[derive(Serialize)]
+pub struct MatchConfig {
+    pub game: u8,
+    pub mode: u8,
+    pub grid_size: u32,
+    pub selection: u8,
+    pub target_medal: u8,
+    pub discovery: bool,
+    pub secret: bool,
+    pub time_limit: i64,
+    pub no_bingo_duration: i64,
+    pub overtime: bool,
+    pub late_join: bool,
+    pub rerolls: bool,
+    pub competitve_patch: bool,
+    pub mappack_id: Option<u32>,
+    pub campaign_selection: Option<Vec<u32>>,
+    pub map_tag: Option<i32>,
+    pub items: FrenzyItemSettings,
+    pub items_expire: u32,
+    pub items_tick_multiplier: u32,
+    pub rally_length: u32,
+    pub jail_length: u32,
+}
+
+#[derive(Serialize)]
+pub struct FrenzyItemSettings {
+    pub row_shift: u32,
+    pub column_shift: u32,
+    pub rally: u32,
+    pub jail: u32,
+    pub rainbow: u32,
+    pub golden_dice: u32,
+}
+
+#[derive(Serialize)]
+pub struct Team {
+    pub id: usize,
+    pub name: String,
+    pub color: [u8; 3],
+}
+
+#[derive(Serialize)]
+pub struct JoinRoomFields {
+    pub join_code: String,
+}
+
+#[derive(Serialize)]
+pub struct SendChatMessageFields {
+    pub message: String,
+}
+
+// -- Helpers --
+
+impl Default for RoomConfig {
+    fn default() -> Self {
+        Self {
+            name: "Bench Room".into(),
+            public: false,
+            randomize: false,
+            size: 0,
+            host_control: false,
+        }
+    }
+}
+
+impl Default for MatchConfig {
+    fn default() -> Self {
+        Self {
+            game: 0,
+            mode: 0,
+            grid_size: 5,
+            selection: 0,
+            target_medal: 1,
+            discovery: false,
+            secret: false,
+            time_limit: 0,
+            no_bingo_duration: 0,
+            overtime: true,
+            late_join: true,
+            rerolls: true,
+            competitve_patch: false,
+            mappack_id: None,
+            campaign_selection: None,
+            map_tag: Some(3),
+            items: FrenzyItemSettings::default(),
+            items_expire: 600,
+            items_tick_multiplier: 1000,
+            rally_length: 600,
+            jail_length: 600,
+        }
+    }
+}
+
+impl Default for FrenzyItemSettings {
+    fn default() -> Self {
+        Self {
+            row_shift: 3,
+            column_shift: 3,
+            rally: 3,
+            jail: 3,
+            rainbow: 3,
+            golden_dice: 3,
+        }
+    }
+}

--- a/server/src/bin/bench/scenarios.rs
+++ b/server/src/bin/bench/scenarios.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{bail, Result};
 use futures::future::join_all;
+use rand::Rng;
 use tokio::task::JoinHandle;
 
 use crate::client::BenchClient;
@@ -302,4 +303,129 @@ pub async fn ping_throughput(addr: &str, num_clients: u32, duration_secs: u64) -
         wall_time,
         latency,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: Run Submission Storm
+// ---------------------------------------------------------------------------
+
+pub async fn run_submission(addr: &str, num_clients: u32, grid_size: u32) -> Result<Stats> {
+    let cell_count = (grid_size * grid_size) as usize;
+    println!("  setting up room with {num_clients} clients (grid {grid_size}x{grid_size})...");
+
+    // Host creates room
+    let mut host = BenchClient::connect(addr, 0).await?;
+    let resp = host.request(
+        "CreateRoom",
+        CreateRoomFields {
+            config: RoomConfig { size: 0, ..Default::default() },
+            match_config: MatchConfig {
+                grid_size,
+                overtime: false,
+                time_limit: 0,
+                no_bingo_duration: 0,
+                ..Default::default()
+            },
+            teams: vec![
+                Team { id: 0, name: "Team A".into(), color: [255, 0, 0] },
+                Team { id: 1, name: "Team B".into(), color: [0, 0, 255] },
+            ],
+        },
+    ).await?;
+
+    let join_code = resp
+        .fields
+        .get("join_code")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("no join_code in CreateRoom response"))?
+        .to_string();
+
+    // Connect and join all clients to the room
+    let mut clients = connect_clients(addr, num_clients, 1).await?;
+    for client in clients.iter_mut() {
+        client.request("JoinRoom", JoinRoomFields { join_code: join_code.clone() }).await?;
+    }
+
+    // Poll StartMatch until maps are loaded
+    println!("  waiting for maps to load...");
+    let start_deadline = Instant::now() + Duration::from_secs(30);
+    let match_uid;
+    loop {
+        if Instant::now() > start_deadline {
+            bail!("timed out waiting for maps to load (30s)");
+        }
+        let result = host.request("StartMatch", StartMatchFields {}).await;
+        match result {
+            Ok(_) => {
+                // Match started — read the MatchStart broadcast to get the uid
+                let evt = host.recv_any().await?;
+                match evt.fields.get("uid").and_then(|v| v.as_str()) {
+                    Some(uid) => {
+                        match_uid = uid.to_string();
+                        break;
+                    }
+                    None => bail!("StartMatch ok but no MatchStart broadcast with uid received"),
+                }
+            }
+            Err(_) => {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+    println!("  match started: {match_uid}");
+
+    // All clients join the match
+    for client in clients.iter_mut() {
+        client.request("JoinMatch", JoinMatchFields {
+            uid: match_uid.clone(),
+            team_id: None,
+        }).await?;
+    }
+    println!("  all clients joined match, submitting runs...");
+
+    // Fire concurrent SubmitRun requests from all clients
+    let wall_start = Instant::now();
+
+    let mut handles: Vec<JoinHandle<Result<Vec<Duration>>>> = Vec::new();
+    for mut client in clients.drain(..) {
+        let cells = cell_count;
+        // Pre-generate random times (ThreadRng is not Send)
+        let times: Vec<u64> = {
+            let mut rng = rand::thread_rng();
+            (0..cells).map(|_| rng.gen_range(30_000..120_000u64)).collect()
+        };
+        handles.push(tokio::spawn(async move {
+            let mut latencies = Vec::new();
+            // Each client submits a run to each cell
+            for (tile_index, time) in times.into_iter().enumerate() {
+                let start = Instant::now();
+                client.request("SubmitRun", SubmitRunFields {
+                    tile_index,
+                    time,
+                    medal: 2, // Gold
+                    splits: vec![],
+                }).await?;
+                latencies.push(start.elapsed());
+            }
+            Ok(latencies)
+        }));
+    }
+
+    let results = join_all(handles).await;
+    let wall_time = wall_start.elapsed();
+
+    let mut durations = Vec::new();
+    for result in results {
+        match result {
+            Ok(Ok(lats)) => durations.extend(lats),
+            Ok(Err(e)) => eprintln!("  submit failed: {e}"),
+            Err(e) => eprintln!("  submit task panicked: {e}"),
+        }
+    }
+
+    if durations.is_empty() {
+        bail!("all submissions failed");
+    }
+
+    Ok(Stats::from_durations(durations, wall_time))
 }

--- a/server/src/bin/bench/scenarios.rs
+++ b/server/src/bin/bench/scenarios.rs
@@ -1,0 +1,305 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Result};
+use futures::future::join_all;
+use tokio::task::JoinHandle;
+
+use crate::client::BenchClient;
+use crate::protocol::*;
+
+/// Stats collected from a set of latency measurements.
+pub struct Stats {
+    pub count: usize,
+    pub p50: Duration,
+    pub p95: Duration,
+    pub p99: Duration,
+    pub max: Duration,
+    pub wall_time: Duration,
+}
+
+impl Stats {
+    pub fn from_durations(mut durations: Vec<Duration>, wall_time: Duration) -> Self {
+        durations.sort();
+        let n = durations.len();
+        Self {
+            count: n,
+            p50: durations[n / 2],
+            p95: durations[(n as f64 * 0.95) as usize],
+            p99: durations[(n as f64 * 0.99) as usize],
+            max: durations[n - 1],
+            wall_time,
+        }
+    }
+}
+
+/// Connect N clients, returning those that succeeded.
+/// Bails if more than 10% fail.
+async fn connect_clients(addr: &str, count: u32, start_index: u32) -> Result<Vec<BenchClient>> {
+    let mut handles: Vec<JoinHandle<Result<BenchClient>>> = Vec::new();
+    for i in 0..count {
+        let addr = addr.to_string();
+        handles.push(tokio::spawn(async move {
+            BenchClient::connect(&addr, start_index + i).await
+        }));
+    }
+
+    let results = join_all(handles).await;
+    let mut clients = Vec::new();
+    let mut failures = 0u32;
+    for result in results {
+        match result {
+            Ok(Ok(client)) => clients.push(client),
+            Ok(Err(e)) => {
+                eprintln!("  client connect failed: {e}");
+                failures += 1;
+            }
+            Err(e) => {
+                eprintln!("  client task panicked: {e}");
+                failures += 1;
+            }
+        }
+    }
+
+    let threshold = (count as f64 * 0.1).ceil() as u32;
+    if failures > threshold {
+        bail!(
+            "{failures}/{count} clients failed to connect (>{} allowed)",
+            threshold
+        );
+    }
+    if !clients.is_empty() {
+        println!("  connected {}/{count} clients", clients.len());
+    }
+    Ok(clients)
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Room Join Storm
+// ---------------------------------------------------------------------------
+
+pub async fn join_storm(addr: &str, num_clients: u32) -> Result<Stats> {
+    println!("  setting up: creating room with host client...");
+
+    // Host client creates the room
+    let mut host = BenchClient::connect(addr, 0).await?;
+    let resp = host.request(
+        "CreateRoom",
+        CreateRoomFields {
+            config: RoomConfig {
+                size: 0, // unlimited
+                ..Default::default()
+            },
+            match_config: MatchConfig::default(),
+            teams: vec![
+                Team { id: 0, name: "Team A".into(), color: [255, 0, 0] },
+                Team { id: 1, name: "Team B".into(), color: [0, 0, 255] },
+            ],
+        },
+    ).await?;
+
+    let join_code = resp
+        .fields
+        .get("join_code")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("no join_code in CreateRoom response"))?
+        .to_string();
+    println!("  room created with code: {join_code}");
+
+    // Connect all joiner clients first (handshake only)
+    println!("  connecting {num_clients} clients...");
+    let mut joiners = connect_clients(addr, num_clients, 1).await?;
+
+    // Now fire all JoinRoom requests concurrently and measure each
+    println!("  joining all clients to room...");
+    let wall_start = Instant::now();
+
+    let mut handles: Vec<JoinHandle<Result<Duration>>> = Vec::new();
+    for mut client in joiners.drain(..) {
+        let code = join_code.clone();
+        handles.push(tokio::spawn(async move {
+            let start = Instant::now();
+            client.request("JoinRoom", JoinRoomFields { join_code: code }).await?;
+            Ok(start.elapsed())
+        }));
+    }
+
+    let results = join_all(handles).await;
+    let wall_time = wall_start.elapsed();
+
+    let mut durations = Vec::new();
+    for result in results {
+        match result {
+            Ok(Ok(d)) => durations.push(d),
+            Ok(Err(e)) => eprintln!("  join failed: {e}"),
+            Err(e) => eprintln!("  join task panicked: {e}"),
+        }
+    }
+
+    if durations.is_empty() {
+        bail!("all joins failed");
+    }
+
+    Ok(Stats::from_durations(durations, wall_time))
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Broadcast Fan-out
+// ---------------------------------------------------------------------------
+
+pub async fn broadcast_fanout(addr: &str, num_clients: u32) -> Result<Stats> {
+    println!("  setting up room with {num_clients} clients...");
+
+    // Host creates room
+    let mut host = BenchClient::connect(addr, 0).await?;
+    let resp = host.request(
+        "CreateRoom",
+        CreateRoomFields {
+            config: RoomConfig { size: 0, ..Default::default() },
+            match_config: MatchConfig::default(),
+            teams: vec![
+                Team { id: 0, name: "Team A".into(), color: [255, 0, 0] },
+                Team { id: 1, name: "Team B".into(), color: [0, 0, 255] },
+            ],
+        },
+    ).await?;
+
+    let join_code = resp
+        .fields
+        .get("join_code")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("no join_code in CreateRoom response"))?
+        .to_string();
+
+    // Connect and join all clients
+    let mut clients = connect_clients(addr, num_clients, 1).await?;
+    for client in clients.iter_mut() {
+        client.request("JoinRoom", JoinRoomFields { join_code: join_code.clone() }).await?;
+    }
+    println!("  all clients joined, sending broadcast...");
+
+    // Host sends a chat message, all clients wait for the broadcast
+    let wall_start = Instant::now();
+
+    // Send chat from host
+    host.request("SendChatMessage", SendChatMessageFields {
+        message: "benchmark ping".into(),
+    }).await?;
+
+    // Each client waits for the ChatMessage broadcast
+    let mut handles: Vec<JoinHandle<Result<Duration>>> = Vec::new();
+    for mut client in clients.drain(..) {
+        let start = wall_start;
+        handles.push(tokio::spawn(async move {
+            loop {
+                let msg = client.recv_any().await?;
+                // Broadcast events from chat contain a "ChatMessage" variant
+                if let Some(content) = msg.fields.get("content") {
+                    if content.as_str() == Some("benchmark ping") {
+                        return Ok(start.elapsed());
+                    }
+                }
+            }
+        }));
+    }
+
+    let results = join_all(handles).await;
+    let wall_time = wall_start.elapsed();
+
+    let mut durations = Vec::new();
+    for result in results {
+        match result {
+            Ok(Ok(d)) => durations.push(d),
+            Ok(Err(e)) => eprintln!("  recv failed: {e}"),
+            Err(e) => eprintln!("  recv task panicked: {e}"),
+        }
+    }
+
+    if durations.is_empty() {
+        bail!("no clients received the broadcast");
+    }
+
+    Ok(Stats::from_durations(durations, wall_time))
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: Sustained Ping Throughput
+// ---------------------------------------------------------------------------
+
+pub struct PingStats {
+    pub total_requests: u64,
+    pub wall_time: Duration,
+    pub latency: Stats,
+}
+
+pub async fn ping_throughput(addr: &str, num_clients: u32, duration_secs: u64) -> Result<PingStats> {
+    println!("  setting up room with {num_clients} clients...");
+
+    // Host creates room
+    let mut host = BenchClient::connect(addr, 0).await?;
+    let resp = host.request(
+        "CreateRoom",
+        CreateRoomFields {
+            config: RoomConfig { size: 0, ..Default::default() },
+            match_config: MatchConfig::default(),
+            teams: vec![
+                Team { id: 0, name: "Team A".into(), color: [255, 0, 0] },
+                Team { id: 1, name: "Team B".into(), color: [0, 0, 255] },
+            ],
+        },
+    ).await?;
+
+    let join_code = resp
+        .fields
+        .get("join_code")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("no join_code in CreateRoom response"))?
+        .to_string();
+
+    let mut clients = connect_clients(addr, num_clients, 1).await?;
+    for client in clients.iter_mut() {
+        client.request("JoinRoom", JoinRoomFields { join_code: join_code.clone() }).await?;
+    }
+    println!("  running pings for {duration_secs}s...");
+
+    let test_duration = Duration::from_secs(duration_secs);
+    let wall_start = Instant::now();
+
+    let mut handles: Vec<JoinHandle<Vec<Duration>>> = Vec::new();
+    for mut client in clients.drain(..) {
+        let dur = test_duration;
+        handles.push(tokio::spawn(async move {
+            let mut latencies = Vec::new();
+            let start = Instant::now();
+            while start.elapsed() < dur {
+                let ping_start = Instant::now();
+                if client.ping().await.is_ok() {
+                    latencies.push(ping_start.elapsed());
+                }
+            }
+            latencies
+        }));
+    }
+
+    let results = join_all(handles).await;
+    let wall_time = wall_start.elapsed();
+
+    let mut all_latencies = Vec::new();
+    for result in results {
+        if let Ok(latencies) = result {
+            all_latencies.extend(latencies);
+        }
+    }
+
+    if all_latencies.is_empty() {
+        bail!("no pings succeeded");
+    }
+
+    let total_requests = all_latencies.len() as u64;
+    let latency = Stats::from_durations(all_latencies, wall_time);
+
+    Ok(PingStats {
+        total_requests,
+        wall_time,
+        latency,
+    })
+}

--- a/server/src/bin/bench/scenarios.rs
+++ b/server/src/bin/bench/scenarios.rs
@@ -323,7 +323,9 @@ pub async fn run_submission(addr: &str, num_clients: u32, grid_size: u32) -> Res
                 grid_size,
                 overtime: false,
                 time_limit: 0,
-                no_bingo_duration: 0,
+                // Keep the match in NoBingo phase so completing a row doesn't end
+                // the match mid-benchmark.
+                no_bingo_duration: 3_600_000,
                 ..Default::default()
             },
             teams: vec![
@@ -357,15 +359,24 @@ pub async fn run_submission(addr: &str, num_clients: u32, grid_size: u32) -> Res
         let result = host.request("StartMatch", StartMatchFields {}).await;
         match result {
             Ok(_) => {
-                // Match started — read the MatchStart broadcast to get the uid
-                let evt = host.recv_any().await?;
-                match evt.fields.get("uid").and_then(|v| v.as_str()) {
-                    Some(uid) => {
-                        match_uid = uid.to_string();
-                        break;
+                // Match started — read broadcasts until we find the MatchStart event
+                let deadline = Instant::now() + Duration::from_secs(10);
+                loop {
+                    if Instant::now() > deadline {
+                        bail!("timed out waiting for MatchStart broadcast");
                     }
-                    None => bail!("StartMatch ok but no MatchStart broadcast with uid received"),
+                    let evt = host.recv_any().await?;
+                    if evt.fields.get("event").and_then(|v| v.as_str()) == Some("MatchStart") {
+                        match evt.fields.get("uid").and_then(|v| v.as_str()) {
+                            Some(uid) => {
+                                match_uid = uid.to_string();
+                                break;
+                            }
+                            None => bail!("MatchStart broadcast missing uid field"),
+                        }
+                    }
                 }
+                break;
             }
             Err(_) => {
                 tokio::time::sleep(Duration::from_millis(500)).await;

--- a/server/src/bin/bench/scenarios.rs
+++ b/server/src/bin/bench/scenarios.rs
@@ -385,25 +385,62 @@ pub async fn run_submission(addr: &str, num_clients: u32, grid_size: u32) -> Res
     }
     println!("  match started: {match_uid}");
 
-    // All clients join the match
-    for client in clients.iter_mut() {
-        client.request("JoinMatch", JoinMatchFields {
-            uid: match_uid.clone(),
-            team_id: None,
-        }).await?;
+    // All clients join the match concurrently.
+    // Drain the host connection in parallel to prevent backpressure from
+    // unread broadcasts blocking the server.
+    let mut handles: Vec<JoinHandle<Result<BenchClient>>> = Vec::new();
+    for client in clients.drain(..) {
+        let uid = match_uid.clone();
+        handles.push(tokio::spawn(async move {
+            let mut c = client;
+            c.request("JoinMatch", JoinMatchFields {
+                uid,
+                team_id: None,
+            }).await?;
+            Ok(c)
+        }));
     }
+
+    let join_future = join_all(handles);
+    tokio::pin!(join_future);
+
+    let mut got_phase_change = false;
+    let join_results = loop {
+        tokio::select! {
+            results = &mut join_future => {
+                break results;
+            }
+            msg = host.recv_any() => {
+                // Check for PhaseChange among drained broadcasts
+                if let Ok(evt) = msg {
+                    if evt.fields.get("event").and_then(|v| v.as_str()) == Some("PhaseChange") {
+                        got_phase_change = true;
+                    }
+                }
+            }
+        }
+    };
+
+    clients = Vec::new();
+    for result in join_results {
+        clients.push(result??);
+    }
+
     // Wait for the NoBingo phase to activate before submitting runs.
     // The match starts in "Starting" phase where bingo checks are active;
     // we need to wait for the PhaseChange broadcast.
-    println!("  waiting for NoBingo phase...");
-    let phase_deadline = Instant::now() + Duration::from_secs(10);
-    loop {
-        if Instant::now() > phase_deadline {
-            bail!("timed out waiting for PhaseChange broadcast");
-        }
-        let evt = host.recv_any().await?;
-        if evt.fields.get("event").and_then(|v| v.as_str()) == Some("PhaseChange") {
-            break;
+    // It may have already arrived during the JoinMatch drain above.
+    if !got_phase_change {
+        println!("  waiting for NoBingo phase...");
+        let phase_deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if Instant::now() > phase_deadline {
+                bail!("timed out waiting for PhaseChange broadcast");
+            }
+            let evt = host.recv_any().await?;
+            if evt.fields.get("event").and_then(|v| v.as_str()) == Some("PhaseChange") {
+                break;
+            }
         }
     }
     println!("  submitting runs...");

--- a/server/src/bin/bench/scenarios.rs
+++ b/server/src/bin/bench/scenarios.rs
@@ -392,7 +392,21 @@ pub async fn run_submission(addr: &str, num_clients: u32, grid_size: u32) -> Res
             team_id: None,
         }).await?;
     }
-    println!("  all clients joined match, submitting runs...");
+    // Wait for the NoBingo phase to activate before submitting runs.
+    // The match starts in "Starting" phase where bingo checks are active;
+    // we need to wait for the PhaseChange broadcast.
+    println!("  waiting for NoBingo phase...");
+    let phase_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if Instant::now() > phase_deadline {
+            bail!("timed out waiting for PhaseChange broadcast");
+        }
+        let evt = host.recv_any().await?;
+        if evt.fields.get("event").and_then(|v| v.as_str()) == Some("PhaseChange") {
+            break;
+        }
+    }
+    println!("  submitting runs...");
 
     // Fire concurrent SubmitRun requests from all clients
     let wall_start = Instant::now();

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -109,7 +109,7 @@ fn populate_configuration_keys(
 }
 
 /// Initialize configuration. Only call this once.
-pub fn initialize() -> bool {
+pub fn initialize(config_path: &str) -> bool {
     let default_data = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/data/config.default.toml"
@@ -122,7 +122,7 @@ pub fn initialize() -> bool {
         toml::from_str(default_data).expect("default configuration has invalid syntax");
     populate_configuration_keys(&mut configuration, &default_config, String::new());
 
-    match fs::read_to_string("config.toml") {
+    match fs::read_to_string(config_path) {
         Ok(text) => {
             let config_overrides: Map<String, Value> = match toml::from_str(&text) {
                 Ok(map) => map,
@@ -135,7 +135,7 @@ pub fn initialize() -> bool {
         }
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
             info!("configuration file not found, created a new copy of the default configuration.");
-            fs::write("config.toml", default_data).unwrap();
+            fs::write(config_path, default_data).unwrap();
         }
         Err(e) => {
             error!("IO error reading configuration file: {e}");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -34,7 +34,11 @@ async fn main() {
     info!("Trackmania Bingo Server: Version {VERSION}");
 
     // Load configuration
-    config::initialize();
+    let config_path = std::env::args()
+        .skip_while(|a| a != "--config")
+        .nth(1)
+        .unwrap_or_else(|| "config.toml".to_string());
+    config::initialize(&config_path);
     config::enumerate_keys();
 
     // Database setup

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, time::Duration};
 
 use client::ClientCallbackImplementation;
 use tokio::net::TcpSocket;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{config, server::client::NetClient};
 
@@ -51,10 +51,13 @@ impl NetServer {
         let listener = self.socket.listen(backlog).expect("TCP listener not created");
 
         loop {
-            let (incoming, remote_addr) = listener
-                .accept()
-                .await
-                .expect("failed to accept an incoming connection");
+            let (incoming, remote_addr) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    warn!("failed to accept connection: {}", e);
+                    continue;
+                }
+            };
 
             let mut client = NetClient::new(incoming, client_timeout);
             client.set_callback_mode(ClientCallbackImplementation::Handshake);

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -45,7 +45,10 @@ impl NetServer {
     /// Run the main server loop.
     pub async fn run(self) {
         let client_timeout = get_client_timeout_config();
-        let listener = self.socket.listen(256).expect("TCP listener not created");
+        let backlog = config::get_integer("network.backlog")
+            .expect("configuration key network.backlog not specified")
+            as u32;
+        let listener = self.socket.listen(backlog).expect("TCP listener not created");
 
         loop {
             let (incoming, remote_addr) = listener


### PR DESCRIPTION
  Summary
                                                                                                                                                                                                                                                              
  - Add a benchmarking harness (cargo run --bin bench) with join_storm and run_submission scenarios for stress-testing the server with many simulated clients                                                                                                      
  - Add JSON output/compare mode for tracking performance across runs                                                                                                                                                                                         
  - Server now takes config path as an argument
  - **Make TCP listen backlog in the server configurable - and double it (kept much higher for benchmark config)**                                                                                                                                   
                                                                                                                                                                                                                                                              
  Test plan                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                              
  - cargo test passes                                                                                                                                                                                                                                         
  - cargo run --bin bench -- --scenario join_storm --clients 200 --spawn-server completes without errors
  - cargo run --bin bench -- --scenario run_submission --clients 50 --spawn-server completes without errors                                                                                                                                                   
  - JSON output/compare works: --output baseline.json then --compare baseline.json                                                                                                                                                                            

Existing runs:
  - Serializing events once instead of per-peer (efc83da), improves join_storm p50/p95 latency by 30-40%            

  🤖 Generated with Claude Code  