### PR TITLE
Server: Share serialized broadcast payloads

### DIFF
--- a/server/src/transport/channel.rs
+++ b/server/src/transport/channel.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::collections::HashMap;
 
 use serde::Serialize;
@@ -28,7 +29,7 @@ impl Channel {
 
     pub fn broadcast(&mut self, message: &impl Serialize) {
         let serialized = match to_vec(message) {
-            Ok(message) => message,
+            Ok(message) => Bytes::from(message),
             Err(e) => {
                 error!("serialization failure: {}", e);
                 return;

--- a/server/src/transport/client/tcpnative.rs
+++ b/server/src/transport/client/tcpnative.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use futures::{SinkExt, StreamExt};
 use serde::Serialize;
 use tokio::{net::TcpStream, sync::mpsc::error::SendError};
@@ -24,12 +24,12 @@ impl NativeClientProtocol {
         self.inner.next().await
     }
 
-    pub async fn write(&mut self, message: Vec<u8>) -> Result<(), io::Error> {
+    pub async fn write(&mut self, message: Bytes) -> Result<(), io::Error> {
         self.inner.send(message.into()).await
     }
 }
 
-pub fn write<S: Serialize>(tx: &TransportWriteQueue, value: &S) -> Result<(), SendError<Vec<u8>>> {
+pub fn write<S: Serialize>(tx: &TransportWriteQueue, value: &S) -> Result<(), SendError<Bytes>> {
     tx.send(
         serde_json::to_string(value)
             .expect("Serialize should not error")

--- a/server/src/transport/messager.rs
+++ b/server/src/transport/messager.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -23,14 +24,14 @@ impl NetMessageWriter {
         Self { writer }
     }
 
-    pub fn send_serialized(&self, message: Vec<u8>) -> Result<(), SendError<Vec<u8>>> {
+    pub fn send_serialized(&self, message: Bytes) -> Result<(), SendError<Bytes>> {
         self.writer.send(message)
     }
 
     /// Send a serialized message to the client.
-    pub fn send<T: Serialize>(&self, message: &T) -> Result<(), Option<SendError<Vec<u8>>>> {
+    pub fn send<T: Serialize>(&self, message: &T) -> Result<(), Option<SendError<Bytes>>> {
         let serialized = match to_vec(message) {
-            Ok(message) => message,
+            Ok(message) => Bytes::from(message),
             Err(e) => {
                 error!("serilization failure: {}", e);
                 return Err(None);

--- a/server/src/transport/mod.rs
+++ b/server/src/transport/mod.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 pub mod channel;
@@ -5,5 +6,5 @@ pub mod client;
 pub mod messager;
 pub use channel::Channel;
 
-pub(crate) type TransportWriteQueue = UnboundedSender<Vec<u8>>;
-pub(crate) type TransportReadQueue = UnboundedReceiver<Vec<u8>>;
+pub(crate) type TransportWriteQueue = UnboundedSender<Bytes>;
+pub(crate) type TransportReadQueue = UnboundedReceiver<Bytes>;


### PR DESCRIPTION
I dug around a bit more after the previous fix (0d6cf7da8e46957359c74cc249dd51934c2efeba) and realized with 1000 users, cloning each broadcasted message 1000 times even after serialization is not optimal and will still use a lot of resources. With this patch the write queue is changed from Vec<u8> to bytes::Bytes so a single serialized payload can be shared across all subscribers.

I have run generated tests that indicate that it works as expected, but not tested fully with real clients.