### PR TITLE
Perf/micro optimizations

### DIFF
--- a/server/src/server/client.rs
+++ b/server/src/server/client.rs
@@ -1,12 +1,11 @@
 use bytes::BytesMut;
-use futures::FutureExt;
 use serde_json::json;
 use std::sync::atomic::{self, AtomicU64};
 use std::time::Duration;
 use tokio::net::TcpStream;
 use tokio::select;
 use tokio::sync::mpsc::unbounded_channel;
-use tokio::time::{timeout_at, Instant};
+use tokio::time::Instant;
 use tracing::{debug, error, warn};
 
 use super::handshake;
@@ -86,36 +85,28 @@ impl NetClient {
 
     /// Run the main loop of the client.
     pub async fn run(mut self) {
-        let mut timeout_deadline = Instant::now() + self.timeout;
-        loop {
-            let next_message_received =
-                timeout_at(timeout_deadline, self.protocol.receive_message().fuse());
-            let outgoing_message_queued = self.receiver.recv().fuse();
+        let sleep = tokio::time::sleep(self.timeout);
+        tokio::pin!(sleep);
 
+        loop {
             select! {
-                timed_result = next_message_received => match timed_result {
-                    Ok(option_message) => match option_message {
-                        Some(result) => match result {
-                            Ok(message) => {
-                                self.handle_message(message).await;
-                                timeout_deadline = Instant::now() + self.timeout;
-                            },
-                            Err(err) => {
-                                error!(cid = self.cid, "socket read error: {}", err);
-                                break;
-                            }
+                option_message = self.protocol.receive_message() => match option_message {
+                    Some(result) => match result {
+                        Ok(message) => {
+                            self.handle_message(message).await;
+                            sleep.as_mut().reset(Instant::now() + self.timeout);
                         },
-                        None => {
-                            debug!(cid = self.cid, "closed connection by remote client");
+                        Err(err) => {
+                            error!(cid = self.cid, "socket read error: {}", err);
                             break;
                         }
                     },
-                    Err(timeout) => {
-                        debug!(cid = self.cid, "timed out: {}", timeout);
+                    None => {
+                        debug!(cid = self.cid, "closed connection by remote client");
                         break;
                     }
                 },
-                queued_message = outgoing_message_queued => match queued_message {
+                queued_message = self.receiver.recv() => match queued_message {
                     Some(message) => match self.protocol.write(message).await {
                         Ok(()) => (),
                         Err(err) => {
@@ -130,6 +121,10 @@ impl NetClient {
                         );
                         break;
                     }
+                },
+                () = &mut sleep => {
+                    debug!(cid = self.cid, "timed out");
+                    break;
                 }
             }
         }

--- a/server/src/transport/channel.rs
+++ b/server/src/transport/channel.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use bytes::Bytes;
 use serde::Serialize;
 use serde_json::to_vec;
 use tracing::error;
@@ -27,8 +28,8 @@ impl Channel {
     }
 
     pub fn broadcast(&mut self, message: &impl Serialize) {
-        let serialized = match to_vec(message) {
-            Ok(message) => message,
+        let serialized: Bytes = match to_vec(message) {
+            Ok(message) => message.into(),
             Err(e) => {
                 error!("serialization failure: {}", e);
                 return;

--- a/server/src/transport/client/tcpnative.rs
+++ b/server/src/transport/client/tcpnative.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use futures::{SinkExt, StreamExt};
 use serde::Serialize;
 use tokio::{net::TcpStream, sync::mpsc::error::SendError};
@@ -24,15 +24,14 @@ impl NativeClientProtocol {
         self.inner.next().await
     }
 
-    pub async fn write(&mut self, message: Vec<u8>) -> Result<(), io::Error> {
-        self.inner.send(message.into()).await
+    pub async fn write(&mut self, message: Bytes) -> Result<(), io::Error> {
+        self.inner.send(message).await
     }
 }
 
-pub fn write<S: Serialize>(tx: &TransportWriteQueue, value: &S) -> Result<(), SendError<Vec<u8>>> {
+pub fn write<S: Serialize>(tx: &TransportWriteQueue, value: &S) -> Result<(), SendError<Bytes>> {
     tx.send(
-        serde_json::to_string(value)
-            .expect("Serialize should not error")
-            .into(),
+        Bytes::from(serde_json::to_string(value)
+            .expect("Serialize should not error")),
     )
 }

--- a/server/src/transport/messager.rs
+++ b/server/src/transport/messager.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use bytes::Bytes;
 use serde::Serialize;
 use serde_json::to_vec;
 use tokio::sync::mpsc::error::SendError;
@@ -23,14 +24,14 @@ impl NetMessageWriter {
         Self { writer }
     }
 
-    pub fn send_serialized(&self, message: Vec<u8>) -> Result<(), SendError<Vec<u8>>> {
+    pub fn send_serialized(&self, message: Bytes) -> Result<(), SendError<Bytes>> {
         self.writer.send(message)
     }
 
     /// Send a serialized message to the client.
-    pub fn send<T: Serialize>(&self, message: &T) -> Result<(), Option<SendError<Vec<u8>>>> {
-        let serialized = match to_vec(message) {
-            Ok(message) => message,
+    pub fn send<T: Serialize>(&self, message: &T) -> Result<(), Option<SendError<Bytes>>> {
+        let serialized: Bytes = match to_vec(message) {
+            Ok(message) => message.into(),
             Err(e) => {
                 error!("serilization failure: {}", e);
                 return Err(None);

--- a/server/src/transport/mod.rs
+++ b/server/src/transport/mod.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 pub mod channel;
@@ -5,5 +6,5 @@ pub mod client;
 pub mod messager;
 pub use channel::Channel;
 
-pub(crate) type TransportWriteQueue = UnboundedSender<Vec<u8>>;
-pub(crate) type TransportReadQueue = UnboundedReceiver<Vec<u8>>;
+pub(crate) type TransportWriteQueue = UnboundedSender<Bytes>;
+pub(crate) type TransportReadQueue = UnboundedReceiver<Bytes>;


### PR DESCRIPTION
  1. Vec<u8> → Bytes in the transport layer — broadcast to 1000 clients now does a cheap ref-count bump per clone instead of copying the entire serialized buffer. This was ~8% of CPU.
  2. Reuse Sleep future with reset() instead of creating a new timeout_at each loop iteration — eliminates constant timer wheel registration/deregistration churn. This was ~8% of CPU.
