### PR TITLE
Increase TCP listen backlog to 2048 for large lobbies

### DIFF
--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -45,7 +45,7 @@ impl NetServer {
     /// Run the main server loop.
     pub async fn run(self) {
         let client_timeout = get_client_timeout_config();
-        let listener = self.socket.listen(256).expect("TCP listener not created");
+        let listener = self.socket.listen(2048).expect("TCP listener not created");
 
         loop {
             let (incoming, remote_addr) = listener


### PR DESCRIPTION
A backlog of 256 rejects connections when 500+ players try to connect simultaneously. Increasing to 2048 allows 1000+ players to queue their connection handshakes without being dropped.