### PR TITLE
Scale Map Discovery to support 1000+ players

### DIFF
--- a/server/src/integrations/webservices.rs
+++ b/server/src/integrations/webservices.rs
@@ -209,19 +209,29 @@ impl NadeoWebserivcesClient {
         map_id: &str,
         account_ids: &Vec<String>,
     ) -> Result<Vec<WebserivcesMapRecord>, WebservicesError> {
-        let request = self
-            .client
-            .get(CORE_ENDPOINT_MAP_RECORDS_BY_ACCOUNT)
-            .query(&[("accountIdList", account_ids.join(","))])
-            .query(&[("mapId", map_id)]);
-        let response: Vec<WebserivcesMapRecord> = self
-            .send_request(request, NadeoAudience::Core)
-            .await?
-            .json()
-            .await
-            .map_err(WebservicesError::Reqwest)?;
+        const CHUNK_SIZE: usize = 100;
+        let mut all_records = Vec::new();
 
-        Ok(response)
+        for chunk in account_ids.chunks(CHUNK_SIZE) {
+            let request = self
+                .client
+                .get(CORE_ENDPOINT_MAP_RECORDS_BY_ACCOUNT)
+                .query(&[("accountIdList", chunk.join(","))])
+                .query(&[("mapId", map_id)]);
+            let response: Vec<WebserivcesMapRecord> = self
+                .send_request(request, NadeoAudience::Core)
+                .await?
+                .json()
+                .await
+                .map_err(WebservicesError::Reqwest)?;
+
+            if !response.is_empty() {
+                all_records.extend(response);
+                break;
+            }
+        }
+
+        Ok(all_records)
     }
 
     pub async fn live_get_map_leaderboard(

--- a/server/src/server/mapload.rs
+++ b/server/src/server/mapload.rs
@@ -2,6 +2,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use futures::executor::block_on;
+use futures::stream::{self, StreamExt};
 use futures::Future;
 use once_cell::sync::Lazy;
 use sqlx::FromRow;
@@ -166,32 +167,41 @@ pub async fn maps_get_world_record(maps: Vec<GameMap>) -> MaploadResult {
 }
 
 pub async fn maps_verify_discovery(maps: Vec<GameMap>, account_ids: Vec<String>) -> MaploadResult {
-    let mut valid_maps = Vec::new();
-    for map in maps {
-        let valid_map = match map {
-            GameMap::TMX(ref mxmap) => match mxmap.webservices_id {
-                Some(ref webservices_id) => {
-                    sleep(Duration::from_millis(200)).await;
-                    match integrations::NADEOSERVICES_CLIENT
-                        .wait()
-                        .core_get_map_records(webservices_id, &account_ids)
-                        .await
-                    {
-                        Ok(records) => records.first().is_none(),
-                        Err(e) => {
-                            error!("{}", e);
-                            false
+    const CONCURRENT_CHECKS: usize = 5;
+
+    let account_ids = &account_ids;
+    let results: Vec<(GameMap, bool)> = stream::iter(maps)
+        .map(|map| async move {
+            let valid = match map {
+                GameMap::TMX(ref mxmap) => match mxmap.webservices_id {
+                    Some(ref webservices_id) => {
+                        match integrations::NADEOSERVICES_CLIENT
+                            .wait()
+                            .core_get_map_records(webservices_id, account_ids)
+                            .await
+                        {
+                            Ok(records) => records.first().is_none(),
+                            Err(e) => {
+                                error!("{}", e);
+                                false
+                            }
                         }
                     }
-                }
-                None => false,
-            },
-            _ => false,
-        };
+                    None => false,
+                },
+                _ => false,
+            };
+            (map, valid)
+        })
+        .buffer_unordered(CONCURRENT_CHECKS)
+        .collect()
+        .await;
 
-        if valid_map {
-            valid_maps.push(map);
-        }
-    }
+    let valid_maps = results
+        .into_iter()
+        .filter(|(_, valid)| *valid)
+        .map(|(map, _)| map)
+        .collect();
+
     Ok(valid_maps)
 }


### PR DESCRIPTION
Problem:
Map Discovery calls GET /v2/mapRecords/by-account?accountIdList=<all player IDs> with every players UUID in a single query parameter. At 1000 players that's ~37,000 characters in the URL, which exceeds HTTP URL length limits and breaks the request entirely.
Additionally, maps were verified one at a time with a 200ms sleep between each, making verification slow even at small player counts.

Changes:
server/src/integrations/webservices.rs: core_get_map_records
Now splits the account ID list into chunks of 100 per request. It exits early as soon as any chunk returns records (since we only need to know if any player has played the map).

server/src/server/mapload.rs: maps_verify_discovery
Now uses futures::stream::buffer_unordered(5) to check 5 maps concurrently instead of sequentially. The 200ms sleep between requests was removed since the concurrency limit and chunked requests provide natural pacing.

Test results (with own TM service account for access token):
Tested multiple times against the live Nadeo API with 1000 random real player UUIDs and 64 random TMX maps.
Avarage completion time for discovery: 12.2s
API rate limited: No