### PR TITLE
Check if the user wants to receive warnings

### DIFF
--- a/client/src/main.as
+++ b/client/src/main.as
@@ -16,7 +16,10 @@ void Main() {
     UIHome::InitSubtitles();
     Powerups::InitPowerupTextures();
     Modefiles::EnsureAllModefilesCreated();
-    GameUpdates::CheckUnstableConfigurations();
+    if(Settings::UnstableConfigWarnings)
+    {
+        GameUpdates::CheckUnstableConfigurations();
+    }
 
     // Load configuration settings
     PersistantStorage::LoadItems();

--- a/client/src/main.as
+++ b/client/src/main.as
@@ -16,8 +16,7 @@ void Main() {
     UIHome::InitSubtitles();
     Powerups::InitPowerupTextures();
     Modefiles::EnsureAllModefilesCreated();
-    if(Settings::UnstableConfigWarnings)
-    {
+    if (Settings::UnstableConfigWarnings) {
         GameUpdates::CheckUnstableConfigurations();
     }
 


### PR DESCRIPTION
Warnings are currently displayed no matter if the setting is turned on or off, this PR makes the plugin react to the setting