### PR TITLE
server: optimisation

### DIFF
--- a/server/src/orm/mod.rs
+++ b/server/src/orm/mod.rs
@@ -18,6 +18,13 @@ pub async fn start_database(url: &str) {
         .connect(url)
         .await
         .expect("database should be started");
+
+    sqlx::query("PRAGMA journal_mode=WAL").execute(&pool).await.ok();
+    sqlx::query("PRAGMA synchronous=NORMAL").execute(&pool).await.ok();
+    sqlx::query("PRAGMA cache_size=-65536").execute(&pool).await.ok();
+    sqlx::query("PRAGMA temp_store=MEMORY").execute(&pool).await.ok();
+    sqlx::query("PRAGMA mmap_size=33554432").execute(&pool).await.ok();
+
     DB_POOL.get_or_init(|| pool);
 }
 

--- a/server/src/server/client.rs
+++ b/server/src/server/client.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{self, AtomicU64};
 use std::time::Duration;
 use tokio::net::TcpStream;
 use tokio::select;
-use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::mpsc::channel;
 use tokio::time::{timeout_at, Instant};
 use tracing::{debug, error, warn};
 
@@ -34,7 +34,8 @@ pub struct NetClient {
 impl NetClient {
     /// Create a new `NetClient`.
     pub fn new(stream: TcpStream, timeout: Duration) -> Self {
-        let (tx, rx): (TransportWriteQueue, TransportReadQueue) = unbounded_channel();
+        let (tx, rx): (TransportWriteQueue, TransportReadQueue) =
+            channel(crate::transport::CLIENT_CHANNEL_CAPACITY);
         Self {
             cid: CLIENT_ID.fetch_add(1, atomic::Ordering::Relaxed),
             protocol: NativeClientProtocol::new(stream),
@@ -84,6 +85,16 @@ impl NetClient {
         debug!(cid = self.cid(), "close event was dropped");
     }
 
+    async fn flush_outgoing(&mut self) -> bool {
+        while let Ok(message) = self.receiver.try_recv() {
+            if let Err(err) = self.protocol.write(message).await {
+                error!(cid = self.cid, "socket write error during flush: {}", err);
+                return false;
+            }
+        }
+        true
+    }
+
     /// Run the main loop of the client.
     pub async fn run(mut self) {
         let mut timeout_deadline = Instant::now() + self.timeout;
@@ -98,6 +109,9 @@ impl NetClient {
                         Some(result) => match result {
                             Ok(message) => {
                                 self.handle_message(message).await;
+                                if !self.flush_outgoing().await {
+                                    break;
+                                }
                                 timeout_deadline = Instant::now() + self.timeout;
                             },
                             Err(err) => {
@@ -175,8 +189,7 @@ async fn mainloop_message_received(client: &mut NetClient, message: BytesMut) ->
                 },
             };
 
-            // send a response. if it's an error, break the connection
-            if ctx.writer.send(&response).is_err() {
+            if ctx.writer.send_reliable(&response).await.is_err() {
                 return false;
             }
         }

--- a/server/src/store/mod.rs
+++ b/server/src/store/mod.rs
@@ -33,10 +33,40 @@ pub async fn initialize_primary_store(path: &str) {
     file_create(path);
 
     let connection_pool = SqlitePoolOptions::new()
-        .max_connections(5)
+        .max_connections(20)
         .connect(path)
         .await
         .expect("primary store did not start");
+
+    sqlx::query("PRAGMA journal_mode=WAL")
+        .execute(&connection_pool)
+        .await
+        .expect("failed to set journal mode");
+
+    sqlx::query("PRAGMA synchronous=NORMAL")
+        .execute(&connection_pool)
+        .await
+        .expect("failed to set synchronous mode");
+
+    sqlx::query("PRAGMA cache_size=-65536")
+        .execute(&connection_pool)
+        .await
+        .expect("failed to set cache_size");
+
+    sqlx::query("PRAGMA temp_store=MEMORY")
+        .execute(&connection_pool)
+        .await
+        .expect("failed to set temp_store");
+
+    sqlx::query("PRAGMA mmap_size=33554432")
+        .execute(&connection_pool)
+        .await
+        .expect("failed to set mmap_size");
+
+    sqlx::query("PRAGMA busy_timeout=30000")
+        .execute(&connection_pool)
+        .await
+        .expect("failed to set busy_timeout");
 
     let configuration = match get_master_configuration(&connection_pool).await {
         Ok(config) => config,

--- a/server/src/transport/channel.rs
+++ b/server/src/transport/channel.rs
@@ -26,20 +26,23 @@ impl Channel {
         self.peers.remove(&address);
     }
 
+    pub fn peer_count(&self) -> usize {
+        self.peers.len()
+    }
+
     pub fn broadcast(&mut self, message: &impl Serialize) {
         let serialized = match to_vec(message) {
             Ok(message) => message,
             Err(e) => {
-                error!("serialization failure: {}", e);
+                error!("broadcast serialization failure: {}", e);
                 return;
             }
         };
 
-        // send message to all peers and collect closed connections which produced an error
         let closed: Vec<i32> = self
             .peers
             .iter()
-            .filter(|(_, peer)| peer.send_serialized(serialized.clone()).is_err())
+            .filter(|(_, peer)| peer.send_raw(serialized.clone()).is_err_and(|e| e.is_some()))
             .map(|(addr, _)| *addr)
             .collect();
 

--- a/server/src/transport/client/tcpnative.rs
+++ b/server/src/transport/client/tcpnative.rs
@@ -3,7 +3,7 @@ use std::io;
 use bytes::BytesMut;
 use futures::{SinkExt, StreamExt};
 use serde::Serialize;
-use tokio::{net::TcpStream, sync::mpsc::error::SendError};
+use tokio::{net::TcpStream, sync::mpsc::error::TrySendError};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
 use super::TransportWriteQueue;
@@ -29,10 +29,10 @@ impl NativeClientProtocol {
     }
 }
 
-pub fn write<S: Serialize>(tx: &TransportWriteQueue, value: &S) -> Result<(), SendError<Vec<u8>>> {
-    tx.send(
+pub fn write<S: Serialize>(tx: &TransportWriteQueue, value: &S) -> Result<(), TrySendError<Vec<u8>>> {
+    tx.try_send(
         serde_json::to_string(value)
             .expect("Serialize should not error")
-            .into(),
+            .into_bytes(),
     )
 }

--- a/server/src/transport/messager.rs
+++ b/server/src/transport/messager.rs
@@ -1,13 +1,25 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use serde::Serialize;
 use serde_json::to_vec;
-use tokio::sync::mpsc::error::SendError;
-use tracing::error;
+use tokio::sync::mpsc::error::{SendTimeoutError, TrySendError};
+use tracing::{error, trace, warn};
 
 use crate::transport::TransportWriteQueue;
 
 pub type NetMessager = Arc<NetMessageWriter>;
+
+static DROPPED_MESSAGES: AtomicU64 = AtomicU64::new(0);
+static DROPPED_BROADCASTS: AtomicU64 = AtomicU64::new(0);
+
+pub fn take_drop_counts() -> (u64, u64) {
+    (
+        DROPPED_MESSAGES.swap(0, Ordering::Relaxed),
+        DROPPED_BROADCASTS.swap(0, Ordering::Relaxed),
+    )
+}
 
 pub fn new_messager(writer: TransportWriteQueue) -> NetMessager {
     Arc::new(NetMessageWriter::new(writer))
@@ -23,12 +35,7 @@ impl NetMessageWriter {
         Self { writer }
     }
 
-    pub fn send_serialized(&self, message: Vec<u8>) -> Result<(), SendError<Vec<u8>>> {
-        self.writer.send(message)
-    }
-
-    /// Send a serialized message to the client.
-    pub fn send<T: Serialize>(&self, message: &T) -> Result<(), Option<SendError<Vec<u8>>>> {
+    pub fn send<T: Serialize>(&self, message: &T) -> Result<(), Option<TrySendError<Vec<u8>>>> {
         let serialized = match to_vec(message) {
             Ok(message) => message,
             Err(e) => {
@@ -37,6 +44,45 @@ impl NetMessageWriter {
             }
         };
 
-        self.send_serialized(serialized).map_err(Some)
+        match self.writer.try_send(serialized) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => {
+                DROPPED_MESSAGES.fetch_add(1, Ordering::Relaxed);
+                trace!("client channel full, dropping message");
+                Ok(())
+            }
+            Err(e @ TrySendError::Closed(_)) => Err(Some(e)),
+        }
+    }
+
+    pub async fn send_reliable<T: Serialize>(&self, message: &T) -> Result<(), ()> {
+        let serialized = match to_vec(message) {
+            Ok(message) => message,
+            Err(e) => {
+                error!("serilization failure: {}", e);
+                return Err(());
+            }
+        };
+
+        match self.writer.send_timeout(serialized, Duration::from_secs(5)).await {
+            Ok(()) => Ok(()),
+            Err(SendTimeoutError::Timeout(_)) => {
+                warn!("client channel still full after 5s, dropping direct message");
+                DROPPED_MESSAGES.fetch_add(1, Ordering::Relaxed);
+                Err(())
+            }
+            Err(SendTimeoutError::Closed(_)) => Err(()),
+        }
+    }
+
+    pub fn send_raw(&self, bytes: Vec<u8>) -> Result<(), Option<TrySendError<Vec<u8>>>> {
+        match self.writer.try_send(bytes) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => {
+                DROPPED_BROADCASTS.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(e @ TrySendError::Closed(_)) => Err(Some(e)),
+        }
     }
 }

--- a/server/src/transport/mod.rs
+++ b/server/src/transport/mod.rs
@@ -1,9 +1,11 @@
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{Receiver, Sender};
 
 pub mod channel;
 pub mod client;
 pub mod messager;
 pub use channel::Channel;
 
-pub(crate) type TransportWriteQueue = UnboundedSender<Vec<u8>>;
-pub(crate) type TransportReadQueue = UnboundedReceiver<Vec<u8>>;
+pub(crate) const CLIENT_CHANNEL_CAPACITY: usize = 2048;
+
+pub(crate) type TransportWriteQueue = Sender<Vec<u8>>;
+pub(crate) type TransportReadQueue = Receiver<Vec<u8>>;


### PR DESCRIPTION


## changes

- **bounded channels** - client channels were unbounded so with enough players the server would just eat memory forever. capped them at 2048 per client, broadcasts get dropped if the channel is full (which is fine, missing one player join update isnt a big deal)

- **responses dont get lost anymore** - if you opened the plugin while tons of players were joining, the public rooms list would fail to load because the response got buried under broadcast spam. direct responses now wait briefly for space instead of getting silently dropped

- **flush after handling** - responses go out right away now instead of waiting for the next loop tick

- **sqlite tuning** - WAL mode, bigger caches, mmap, busy timeout on both databases. nothing crazy just the usual stuff you should set on sqlite when you have concurrent access

- **20 max connections** instead of 5 on the primary db

## tested

- 8000 players, 220k+ run submissions
- 2000 players with discovery mode
- using the actual client while stress tests were running