### PR TITLE
client: restore disabled plugins when the game ends or the plugin is removed

### DIFF
--- a/client/src/gamemaster.as
+++ b/client/src/gamemaster.as
@@ -254,7 +254,7 @@ namespace Gamemaster {
         ClearMatchId();
         @Match = null;
         @Jail = null;
-        Playground::SetMapLeaderboardVisible(true);
+        ResetInfluence();
         UIChat::ClearHistory();
         UIPoll::ClearAllPollsAndNotifications();
     }
@@ -274,8 +274,8 @@ namespace Gamemaster {
         }
         // Disable jail
         @Jail = null;
-        // Restore map leaderboards for competitive patch
-        Playground::SetMapLeaderboardVisible(true);
+        // Restore map leaderboards and disabled plugins for competitive patch
+        ResetInfluence();
     }
 
     /**
@@ -283,5 +283,15 @@ namespace Gamemaster {
      */
     bool IsLargeServer() {
         return IsBingoActive() && Match.IsLargeServer();
+    }
+
+    /**
+     * Clears the plugin's effects on Trackmania, and other plugins
+     */
+    void ResetInfluence() {
+        Playground::SetMapLeaderboardVisible(true);
+        GameUpdates::RestoreCompetitiveBannedPlugins();
+        GameUpdates::MapIsCompetitivePatched = false;
+        GameUpdates::ManialinkInitialized = false;
     }
 }

--- a/client/src/main.as
+++ b/client/src/main.as
@@ -125,3 +125,12 @@ void Update(float dt) {
     if (Gamemaster::IsBingoPlaying())
         GameUpdates::TickGameplay();
 }
+
+// if the plugin is uninstalled or disabled, remove the plugin's influence on the game and Openplanet
+void OnDisabled() {
+    Gamemaster::ResetInfluence();
+}
+void OnDestroyed() {
+    Gamemaster::ResetInfluence();
+}
+// since we check every frame for records / plugins, we don't need to do anything in OnEnabled

--- a/client/src/playground/next.as
+++ b/client/src/playground/next.as
@@ -20,7 +20,7 @@ namespace Playground {
         return app.RootMap;
     }
 
-    /* Set the visibility of the records leaderbaord manialink module. */
+    /* Set the visibility of the records leaderboard manialink module. */
     bool SetMapLeaderboardVisible(bool visible) {
         auto network = GetApp().Network;
         if (network is null)

--- a/client/src/update.as
+++ b/client/src/update.as
@@ -3,6 +3,8 @@ namespace GameUpdates {
     int64 LastSummonTimestamp;
     bool MapIsCompetitivePatched;
     bool ManialinkInitialized;
+    // plugins which were disabled during the bingo, to restore once it finishes
+    array<string> disabledPlugins = {};
 
     // Run checks and display a warning when using an unsupported config.
     void CheckUnstableConfigurations() {
@@ -69,8 +71,28 @@ namespace GameUpdates {
                 // plugin is blacklisted, disable it
                 logwarn("[GameUpdates::DisableCompetitiveBannedPlugins] Plugin \"" + plugin.ID + "\" is blacklisted in competitive matches, disabling.");
                 plugin.Enabled = false;
+                if (disabledPlugins.Find(plugin.ID) == -1) {
+                    disabledPlugins.InsertLast(plugin.ID);
+                }
             }
         }
+    }
+    void RestoreCompetitiveBannedPlugins() {
+        if (disabledPlugins.Length == 0) {return;}
+        auto plugins = Meta::AllPlugins();
+        for (uint i = 0; i < plugins.Length; i++) {
+            auto plugin = plugins[i];
+            if (plugin.Enabled) {
+                // skip enabled plugins
+                continue;
+            }
+            if (disabledPlugins.Find(plugin.ID) != -1) {
+                // plugin has been disabled by bingo, so re-enable it
+                trace("[GameUpdates::RestoreCompetitiveBannedPlugins] Plugin \"" + plugin.ID + "\" is being re-enabled.");
+                plugin.Enabled = true;
+            }
+        }
+        disabledPlugins = {};
     }
 
     void SummonToJail() {


### PR DESCRIPTION
Currently, the plugins that are disabled by competitive patch are left disabled after the bingo game is finished.
This pr changes that so that any plugins disabled by bingo during the game will be re-enabled.

Uninstalling bingo will also restore the plugins