### PR TITLE
Add include/exclude tag filter

### DIFF
--- a/client/src/datatypes.as
+++ b/client/src/datatypes.as
@@ -147,6 +147,8 @@ namespace MatchConfiguration {
         value["rerolls"] = cls.rerolls;
         value["competitve_patch"] = cls.competitvePatch;
         value["mappack_id"] = cls.mappackId;
+        value["include_tags"] = cls.includeTags;
+        value["exclude_tags"] = cls.excludeTags;
         value["campaign_selection"] = cls.campaignSelection;
         value["map_tag"] = cls.mapTag;
         value["items"] = FrenzyItemSettings::Serialize(cls.items);
@@ -154,8 +156,6 @@ namespace MatchConfiguration {
         value["items_tick_multiplier"] = cls.itemsTickMultiplier;
         value["rally_length"] = cls.rallyLength;
         value["jail_length"] = cls.jailLength;
-        value["include_tags"] = cls.includeTags;
-        value["exclude_tags"] = cls.excludeTags;
 
         return value;
     }
@@ -176,14 +176,14 @@ namespace MatchConfiguration {
         cls.rerolls = value["rerolls"];
         cls.competitvePatch = value["competitve_patch"];
         if (value["mappack_id"].GetType() != Json::Type::Null) cls.mappackId = value["mappack_id"];
-        if (value["campaign_selection"].GetType() != Json::Type::Null) for (uint i = 0; i < value["campaign_selection"].Length; i++) {
-            cls.campaignSelection.InsertLast(value["campaign_selection"][i]);
-        }
         if (value["include_tags"].GetType() != Json::Type::Null) for (uint i = 0; i < value["include_tags"].Length; i++) {
             cls.includeTags.InsertLast(value["include_tags"][i]);
         }
         if (value["exclude_tags"].GetType() != Json::Type::Null) for (uint i = 0; i < value["exclude_tags"].Length; i++) {
-            cls.includeTags.InsertLast(value["exclude_tags"][i]);
+            cls.excludeTags.InsertLast(value["exclude_tags"][i]);
+        }
+        if (value["campaign_selection"].GetType() != Json::Type::Null) for (uint i = 0; i < value["campaign_selection"].Length; i++) {
+            cls.campaignSelection.InsertLast(value["campaign_selection"][i]);
         }
         if (value["map_tag"].GetType() != Json::Type::Null) cls.mapTag = value["map_tag"];
         cls.items = FrenzyItemSettings::Deserialize(value["items"]);

--- a/client/src/datatypes.as
+++ b/client/src/datatypes.as
@@ -119,6 +119,8 @@ class MatchConfiguration {
     bool rerolls = true;
     bool competitvePatch;
     uint mappackId;
+    array<int> includeTags;
+    array<int> excludeTags;
     array<uint> campaignSelection;
     int mapTag = 3;
     FrenzyItemSettings items;
@@ -152,6 +154,8 @@ namespace MatchConfiguration {
         value["items_tick_multiplier"] = cls.itemsTickMultiplier;
         value["rally_length"] = cls.rallyLength;
         value["jail_length"] = cls.jailLength;
+        value["include_tags"] = cls.includeTags;
+        value["exclude_tags"] = cls.excludeTags;
 
         return value;
     }
@@ -174,6 +178,12 @@ namespace MatchConfiguration {
         if (value["mappack_id"].GetType() != Json::Type::Null) cls.mappackId = value["mappack_id"];
         if (value["campaign_selection"].GetType() != Json::Type::Null) for (uint i = 0; i < value["campaign_selection"].Length; i++) {
             cls.campaignSelection.InsertLast(value["campaign_selection"][i]);
+        }
+        if (value["include_tags"].GetType() != Json::Type::Null) for (uint i = 0; i < value["include_tags"].Length; i++) {
+            cls.includeTags.InsertLast(value["include_tags"][i]);
+        }
+        if (value["exclude_tags"].GetType() != Json::Type::Null) for (uint i = 0; i < value["exclude_tags"].Length; i++) {
+            cls.includeTags.InsertLast(value["exclude_tags"][i]);
         }
         if (value["map_tag"].GetType() != Json::Type::Null) cls.mapTag = value["map_tag"];
         cls.items = FrenzyItemSettings::Deserialize(value["items"]);

--- a/client/src/ui/roomsettings.as
+++ b/client/src/ui/roomsettings.as
@@ -7,6 +7,8 @@ namespace UIRoomSettings {
     const float CHECKBOXES_ALIGN_X = 200;
     const float GAME_SETTINGS_ALIGN_X = 160;
 
+    string g_tagSearch = "";
+
     FeaturedMappack @SelectedPack;
     int State;
     string HoveredTrackSelect;
@@ -195,6 +197,78 @@ namespace UIRoomSettings {
         Layout::MoveTo(GAME_SETTINGS_ALIGN_X * UI::GetScale());
         UI::SetNextItemWidth(150);
         MatchConfig.mappackId = UI::InputInt("##bingomappack", MatchConfig.mappackId, 0);
+    }
+
+    void DrawTagsMultiselect(const string &in comboId, int[]@ tags) {
+        if (!MXTags::TagsLoaded()) {
+            UI::BeginDisabled();
+            UI::InputText("##"+comboId, "...");
+            UI::EndDisabled();
+            return;
+        }
+        string label;
+        if (tags.Length == 0) {
+            label = "No tags selected";
+        } else if (tags.Length <= 3) {
+            label = MXTags::AllTagsLookup[tags[0]];
+            for (uint i = 1; i < tags.Length; i++) {
+                label += ", " + MXTags::AllTagsLookup[tags[i]];
+            }
+        } else {
+            label = tags.Length + " tags selected";
+        }
+        if (UI::BeginCombo("##"+comboId, label)) {
+            if (UI::IsWindowAppearing()) {
+                g_tagSearch = "";
+            }
+
+            UI::SetNextItemWidth(200);
+            g_tagSearch = UI::InputText("##"+comboId+"-tagsearch", g_tagSearch);
+
+            UI::Separator();
+
+            for (uint i = 0; i < MXTags::AllTagsSorted.Length; i++) {
+                const auto tag = MXTags::AllTagsSorted[i];
+                if (tag.name == "") continue;
+
+                if (!tag.name.ToLower().Contains(g_tagSearch.ToLower())) {
+                    continue;
+                }
+
+                int idx = tags.Find(tag.id);
+                if (UI::Checkbox(tag.name + "##" + comboId, idx != -1)) {
+                    if (idx == -1) {
+                        tags.InsertLast(tag.id);
+                    }
+                } else {
+                    if (idx != -1) {
+                        tags.RemoveAt(idx);
+                    }
+                }
+            }
+            UI::EndCombo();
+        }
+        UI::BeginDisabled(tags.Length == 0);
+        UI::SameLine();
+#if TMNEXT
+        UI::SetCursorPos(UI::GetCursorPos() - vec2(0, 4));
+#endif
+        if (UI::Button("x##" + comboId)) {
+            tags.RemoveRange(0, tags.Length);
+        }
+        UI::EndDisabled();
+    }
+
+    void MappackTagsInput() {
+        UITools::AlignedLabel(Icons::Exchange + "  Included TMX Tags");
+        Layout::MoveTo(GAME_SETTINGS_ALIGN_X * UI::GetScale());
+        UI::SetNextItemWidth(250);
+        DrawTagsMultiselect("mappackincludedtags", MatchConfig.includeTags);
+
+        UITools::AlignedLabel(Icons::Exchange + "  Excluded TMX Tags");
+        Layout::MoveTo(GAME_SETTINGS_ALIGN_X * UI::GetScale());
+        UI::SetNextItemWidth(250);
+        DrawTagsMultiselect("mappackexcludedtags", MatchConfig.excludeTags);
     }
 
     void MapTagSelector() {
@@ -394,6 +468,7 @@ namespace UIRoomSettings {
         }
         if (MatchConfig.selection == MapMode::Mappack) {
             MappackIdInput();
+            MappackTagsInput();
         }
 
         GridSizeSelector();

--- a/client/src/util/tags.as
+++ b/client/src/util/tags.as
@@ -19,11 +19,16 @@ namespace MXTags {
     array<Tag @>
         Tags = {};
 
+    array<string> AllTagsLookup;
+    array<Tag@> AllTagsSorted;
+
     bool TagsRequested;
 
     bool TagsLoaded() {
-        if (!TagsRequested)
+        if (!TagsRequested) {
+            TagsRequested = true;
             startnew(LoadTags);
+        }
         return Tags.Length > 0;
     }
 
@@ -39,16 +44,31 @@ namespace MXTags {
 
         auto data = Json::Parse(req.String());
         Tags = {};
+        AllTagsLookup = {};
+        AllTagsSorted = {};
+        AllTagsLookup.Resize(data.Length + 1);
         for (uint i = 0; i < data.Length; i++) {
             string name = data[i]["Name"];
             int id = data[i]["ID"];
+
+            auto tag = Tag(id, name);
+            AllTagsSorted.InsertLast(tag);
+            AllTagsLookup[id] = name;
+
             if (id > TAG_MAX_ID || BANNED_TAGS.Find(name) != -1) {
                 continue;
             }
 
-            Tags.InsertLast(Tag(id, name));
+            Tags.InsertLast(tag);
         }
+
+        AllTagsSorted.Sort(_compareTmxTags);
+
         logtrace("[MXTags::LoadTags] Loaded " + Tags.Length + " tags.");
+    }
+
+    bool _compareTmxTags(const Tag@ const &in a, const Tag@ const &in b) {
+        return a.name < b.name;
     }
 
     Tag GetTag(int id) {

--- a/common/types.xml
+++ b/common/types.xml
@@ -54,8 +54,8 @@
         <m name="rerolls" type="bool" default="true" />
         <m name="competitve_patch" type="bool" />
         <m name="mappack_id" type="uint" optional="true" />
-        <m name="include_tags" type="list[uint]" optional="true" />
-        <m name="exclude_tags" type="list[uint]" optional="true" />
+        <m name="include_tags" type="list[int]" optional="true" />
+        <m name="exclude_tags" type="list[int]" optional="true" />
         <m name="campaign_selection" type="list[uint]" optional="true" />
         <m name="map_tag" type="int" optional="true" default="3" />
         <m name="items" type="FrenzyItemSettings" />

--- a/common/types.xml
+++ b/common/types.xml
@@ -54,6 +54,8 @@
         <m name="rerolls" type="bool" default="true" />
         <m name="competitve_patch" type="bool" />
         <m name="mappack_id" type="uint" optional="true" />
+        <m name="include_tags" type="list[uint]" optional="true" />
+        <m name="exclude_tags" type="list[uint]" optional="true" />
         <m name="campaign_selection" type="list[uint]" optional="true" />
         <m name="map_tag" type="int" optional="true" default="3" />
         <m name="items" type="FrenzyItemSettings" />

--- a/server/src/datatypes.rs
+++ b/server/src/datatypes.rs
@@ -81,9 +81,9 @@ pub struct MatchConfiguration {
 	pub rerolls: bool,
     pub competitve_patch: bool,
     pub mappack_id: Option<u32>,
-    pub campaign_selection: Option<Vec<u32>>,
     pub include_tags: Option<Vec<i32>>,
     pub exclude_tags: Option<Vec<i32>>,
+    pub campaign_selection: Option<Vec<u32>>,
     #[derivative(Default(value = "Some(3)"))]
 	pub map_tag: Option<i32>,
     pub items: FrenzyItemSettings,

--- a/server/src/datatypes.rs
+++ b/server/src/datatypes.rs
@@ -82,6 +82,8 @@ pub struct MatchConfiguration {
     pub competitve_patch: bool,
     pub mappack_id: Option<u32>,
     pub campaign_selection: Option<Vec<u32>>,
+    pub include_tags: Option<Vec<i32>>,
+    pub exclude_tags: Option<Vec<i32>>,
     #[derivative(Default(value = "Some(3)"))]
 	pub map_tag: Option<i32>,
     pub items: FrenzyItemSettings,

--- a/server/src/integrations/tmexchange/mappack.rs
+++ b/server/src/integrations/tmexchange/mappack.rs
@@ -79,16 +79,18 @@ impl MappackLoader {
     pub async fn get_mappack_tracks(
         &self,
         mappack_id: &str,
+        include_tags: &[i32],
+        exclude_tags: &[i32],
     ) -> Result<Vec<GameMap>, anyhow::Error> {
         let mut mappack_tracks = Vec::new();
 
         let (mut page_results, mut pagination_next_id) =
-            self.paged_mappack_request_tracks(mappack_id, None).await?;
+            self.paged_mappack_request_tracks(mappack_id, None, include_tags, exclude_tags).await?;
         mappack_tracks.append(&mut page_results);
 
         while pagination_next_id.is_some() {
             (page_results, pagination_next_id) = self
-                .paged_mappack_request_tracks(mappack_id, pagination_next_id)
+                .paged_mappack_request_tracks(mappack_id, pagination_next_id, include_tags, exclude_tags)
                 .await?;
             mappack_tracks.append(&mut page_results);
         }
@@ -100,6 +102,8 @@ impl MappackLoader {
         &self,
         mappack_id: &str,
         after_id: Option<i32>,
+        include_tags: &[i32],
+        exclude_tags: &[i32],
     ) -> Result<(Vec<GameMap>, Option<i32>), anyhow::Error> {
         let query_extra = after_id
             .map(|map_uid| format!("&after={}", map_uid))
@@ -119,9 +123,26 @@ impl MappackLoader {
             .await?;
 
         let more = response.more;
+        let next_id = if more {
+            response.results.last().map(|map| map.map_id)
+        } else {
+            None
+        };
+
         let maps: Vec<MapRecord> = response
             .results
             .into_iter()
+            .filter(|mp| {
+                if !exclude_tags.is_empty() {
+                    if mp.tags.iter().any(|t| exclude_tags.contains(&t.tag_id)) {
+                        return false;
+                    }
+                }
+                if !include_tags.is_empty() {
+                    return mp.tags.iter().any(|t| include_tags.contains(&t.tag_id));
+                }
+                return true;
+            })
             .map(MapRecord::try_from)
             .filter(|m| {
                 if let Err(e) = m {
@@ -132,11 +153,6 @@ impl MappackLoader {
             .map(Result::unwrap) // Safety: Err has been filtered out above
             .collect();
 
-        let next_id = if more {
-            maps.last().map(|map| map.tmxid)
-        } else {
-            None
-        };
         Ok((maps.into_iter().map(GameMap::TMX).collect(), next_id))
     }
 }

--- a/server/src/server/mapload.rs
+++ b/server/src/server/mapload.rs
@@ -61,7 +61,13 @@ fn get_load_future(
             config.grid_size * config.grid_size * number_of_grids,
             config.map_tag.unwrap(),
         )),
-        MapMode::Mappack => Box::pin(network_load_mappack(config.mappack_id.unwrap())),
+        MapMode::Mappack => Box::pin(
+            network_load_mappack(
+                config.mappack_id.unwrap(),
+                config.include_tags.clone().unwrap_or(vec![]),
+                config.exclude_tags.clone().unwrap_or(vec![]),
+            )
+        ),
         #[allow(unreachable_patterns)]
         _ => unimplemented!(),
     }
@@ -118,9 +124,13 @@ async fn cache_load_tag(count: u32, tag: i32) -> MaploadResult {
     .map_err(anyhow::Error::from)
 }
 
-async fn network_load_mappack(mappack_id: u32) -> MaploadResult {
+async fn network_load_mappack(
+    mappack_id: u32,
+    include_tags: Vec<i32>,
+    exclude_tags: Vec<i32>,
+) -> MaploadResult {
     MAPPACK_LOADER
-        .get_mappack_tracks(&mappack_id.to_string())
+        .get_mappack_tracks(&mappack_id.to_string(), include_tags.as_slice(), exclude_tags.as_slice())
         .await
 }
 

--- a/web/datatypes.py
+++ b/web/datatypes.py
@@ -100,6 +100,8 @@ class MatchConfiguration(BaseModel):
     rerolls: bool = True
     competitve_patch: bool
     mappack_id: int | None
+    include_tags: list[int] | None
+    exclude_tags: list[int] | None
     campaign_selection: list[int] | None
     map_tag: int | None = 3
     items: FrenzyItemSettings


### PR DESCRIPTION
Add new include tags and exclude tags filters to the custom mappack bingo mode.

<img width="2034" height="1221" alt="image" src="https://github.com/user-attachments/assets/bf609816-1333-41f0-886b-df3c992af4d4" />

<img width="586" height="238" alt="image" src="https://github.com/user-attachments/assets/3adca2bf-3693-4902-bb49-24b23c610bf8" />

I tested multiple combinations of tags and it seems to work.
However, I didn't come up with a way to test actual multiplayer locally, so very much could miss something not obvious.
Also, I dont know how do you deal with backwards compatibility. I assume it should work fine because I do accept `Option<Vec<i32>>` on server side, meaning older clients should work too, but I havent tested this.

I have not used AI tools for this PR.